### PR TITLE
Use LooseVersion to avoid versioning error

### DIFF
--- a/mrrc/pkgs/maven.py
+++ b/mrrc/pkgs/maven.py
@@ -21,7 +21,7 @@ from mrrc.config import MrrcConfig
 from typing import Dict, List, Tuple
 from jinja2 import Template
 from datetime import datetime
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from zipfile import ZipFile
 from tempfile import mkdtemp
 import os
@@ -45,7 +45,7 @@ class MavenMetadata(object):
         self.artifact_id = artifact_id
         self.last_upd_time = datetime.now().strftime("%Y%m%d%H%M%S")
         self.versions = versions
-        self.sorted_versions = sorted(versions, key=StrictVersion)
+        self.sorted_versions = sorted(versions, key=LooseVersion)
         self._latest_version = None
         self._release_version = None
 

--- a/tests/test_maven_meta.py
+++ b/tests/test_maven_meta.py
@@ -24,6 +24,12 @@ from tests.base import BaseMRRCTest
 
 
 class MavenMetadataTest(BaseMRRCTest):
+    def test_general_meta(self):
+        try:
+            mvn.MavenMetadata("foo", "bar", ["1.0", "1.0.GA"])
+        except ValueError:
+            self.fail("Should not fail here")
+
     def test_parse_ga(self):
         g, a = mvn.parse_ga("org/apache/maven/plugins/maven-plugin-plugin", "")
         self.assertEqual("org.apache.maven.plugins", g)


### PR DESCRIPTION
  Maven versioning used some legacy version style like 1.9.GA, which
  will cause ValueError if using StrictVersion