### PR TITLE
Fix a version comparasion bug

### DIFF
--- a/tests/test_maven_meta.py
+++ b/tests/test_maven_meta.py
@@ -90,3 +90,20 @@ class MavenMetadataTest(BaseMRRCTest):
         self.assertEqual(len(versions), 13)
 
         shutil.rmtree(temp_root)
+
+    def test_ver_cmp_key(self):
+        comp_class = mvn.ver_cmp_key()
+        # Normal versions comparasion
+        self.assertLess(comp_class('1.0.0'), comp_class('1.0.1'))
+        self.assertGreater(comp_class('1.10.0'), comp_class('1.9.1'))
+        self.assertEqual(comp_class('1.0.1'), comp_class('1.0.1'))
+        self.assertEqual(comp_class('1.0.1'), comp_class('1.0.1'))
+        self.assertGreater(comp_class('2.0.1'), comp_class('1.0.1'))
+
+        # Special versions comparasion
+        self.assertGreater(comp_class('1.0.1-alpha'), comp_class('1.0.1'))
+        self.assertGreater(comp_class('1.0.1-beta'), comp_class('1.0.1-alpha'))
+        self.assertGreater(comp_class('1.0.2'), comp_class('1.0.1-alpha'))
+        self.assertGreater(comp_class('1.0.1'), comp_class('1.0-m2'))
+        self.assertGreater(comp_class('1.0.2-alpha'), comp_class('1.0.1-m2'))
+        self.assertGreater(comp_class('1.0.2-alpha'), comp_class('1.0.1-alpha'))


### PR DESCRIPTION
  Maven metadata generation needs to sort the versions, and seems that
  distutils.version.LooseVersion can not handle some edge situations for
  maven cases, like 2.0.8 vs 2.0-m2. See bug reported here:
  https://github.com/pypa/distutils/issues/22