### PR TITLE
Fix: Add trailing index.html for indexing template rendering

### DIFF
--- a/charon/constants.py
+++ b/charon/constants.py
@@ -119,7 +119,11 @@ body {
   <main>
     <pre id="contents">
     {% for item in index.items %}
-          <a href="{{ item }}" title="{{ item }}">{{ item }}</a>
+      {% if item.endswith("/") %}
+        <a href="{{ item }}index.html" title="{{ item }}">{{ item }}</a>
+      {% else %}
+        <a href="{{ item }}" title="{{ item }}">{{ item }}</a>
+      {% endif %}
     {% endfor%}
     </pre>
   </main>

--- a/template/index.html.j2
+++ b/template/index.html.j2
@@ -2,28 +2,32 @@
 <html>
 
 <head>
-	<title>{{ index.title }}</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<style>
+  <title>{{ index.title }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
 body {
-	background: #fff;
+  background: #fff;
 }
-	</style>
+  </style>
 </head>
 
 <body>
-	<header>
-		<h1>{{ index.header }}</h1>
-	</header>
-	<hr/>
-	<main>
-		<pre id="contents">
+  <header>
+    <h1>{{ index.header }}</h1>
+  </header>
+  <hr/>
+  <main>
+    <pre id="contents">
     {% for item in index.items %}
-      		<a href="{{ item }}" title="{{ item }}">{{ item }}</a>
+      {% if item.endswith("/") %}
+        <a href="{{ item }}index.html" title="{{ item }}">{{ item }}</a>
+      {% else %}
+        <a href="{{ item }}" title="{{ item }}">{{ item }}</a>
+      {% endif %}
     {% endfor%}
-		</pre>
-	</main>
-	<hr/>
+    </pre>
+  </main>
+  <hr/>
 </body>
 
 </html>

--- a/tests/test_maven_index.py
+++ b/tests/test_maven_index.py
@@ -98,21 +98,22 @@ class MavenFileIndexTest(BaseTest):
 
         indedx_obj = test_bucket.Object(COMMONS_CLIENT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertIn("<a href=\"4.5.6/index.html\" title=\"4.5.6/\">4.5.6/</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content
         )
-        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_ROOT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
+        self.assertIn("<a href=\"org/index.html\" title=\"org/\">org/</a>", index_content)
         self.assertIn(
-            "<a href=\"commons-logging/\" title=\"commons-logging/\">commons-logging/</a>",
+            "<a href=\"commons-logging/index.html\" "
+            "title=\"commons-logging/\">commons-logging/</a>",
             index_content
         )
-        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
     def test_overlap_upload_index(self):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
@@ -133,29 +134,30 @@ class MavenFileIndexTest(BaseTest):
 
         indedx_obj = test_bucket.Object(COMMONS_CLIENT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
-        self.assertIn("<a href=\"4.5.9/\" title=\"4.5.9/\">4.5.9/</a>", index_content)
+        self.assertIn("<a href=\"4.5.6/index.html\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertIn("<a href=\"4.5.9/index.html\" title=\"4.5.9/\">4.5.9/</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content)
-        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_LOGGING_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"1.2/\" title=\"1.2/\">1.2/</a>", index_content)
+        self.assertIn("<a href=\"1.2/index.html\" title=\"1.2/\">1.2/</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content)
-        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_ROOT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
+        self.assertIn("<a href=\"org/index.html\" title=\"org/\">org/</a>", index_content)
         self.assertIn(
-            "<a href=\"commons-logging/\" title=\"commons-logging/\">commons-logging/</a>",
+            "<a href=\"commons-logging/index.html\" "
+            "title=\"commons-logging/\">commons-logging/</a>",
             index_content
         )
-        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
     def test_deletion_index(self):
         self.__prepare_content()
@@ -186,21 +188,22 @@ class MavenFileIndexTest(BaseTest):
 
         indedx_obj = test_bucket.Object(COMMONS_CLIENT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"4.5.9/\" title=\"4.5.9/\">4.5.9/</a>", index_content)
-        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"4.5.9/index.html\" title=\"4.5.9/\">4.5.9/</a>", index_content)
+        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content)
-        self.assertNotIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertNotIn("<a href=\"4.5.6/index.html\" title=\"4.5.6/\">4.5.6/</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_ROOT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
+        self.assertIn("<a href=\"org/index.html\" title=\"org/\">org/</a>", index_content)
         self.assertIn(
-            "<a href=\"commons-logging/\" title=\"commons-logging/\">commons-logging/</a>",
+            "<a href=\"commons-logging/index.html\" "
+            "title=\"commons-logging/\">commons-logging/</a>",
             index_content
         )
-        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
         product_459 = "commons-client-4.5.9"
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")

--- a/tests/test_npm_index.py
+++ b/tests/test_npm_index.py
@@ -85,14 +85,14 @@ class NpmFileIndexTest(BaseTest):
 
         indedx_obj = test_bucket.Object(CODE_FRAME_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"-/\" title=\"-/\">-/</a>", index_content)
-        self.assertIn("<a href=\"7.14.5/\" title=\"7.14.5/\">7.14.5/</a>", index_content)
-        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"-/index.html\" title=\"-/\">-/</a>", index_content)
+        self.assertIn("<a href=\"7.14.5/index.html\" title=\"7.14.5/\">7.14.5/</a>", index_content)
+        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_ROOT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"@babel/\" title=\"@babel/\">@babel/</a>", index_content)
-        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"@babel/index.html\" title=\"@babel/\">@babel/</a>", index_content)
+        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
     def test_overlap_upload_index(self):
         self.__prepare_content()
@@ -111,10 +111,10 @@ class NpmFileIndexTest(BaseTest):
 
         indedx_obj = test_bucket.Object(CODE_FRAME_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"7.14.5/\" title=\"7.14.5/\">7.14.5/</a>", index_content)
-        self.assertIn("<a href=\"7.15.8/\" title=\"7.15.8/\">7.15.8/</a>", index_content)
-        self.assertIn("<a href=\"-/\" title=\"-/\">-/</a>", index_content)
-        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"7.14.5/index.html\" title=\"7.14.5/\">7.14.5/</a>", index_content)
+        self.assertIn("<a href=\"7.15.8/index.html\" title=\"7.15.8/\">7.15.8/</a>", index_content)
+        self.assertIn("<a href=\"-/index.html\" title=\"-/\">-/</a>", index_content)
+        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
 
     def test_deletion_index(self):
         self.__prepare_content()
@@ -141,10 +141,12 @@ class NpmFileIndexTest(BaseTest):
 
         indedx_obj = test_bucket.Object(CODE_FRAME_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"7.15.8/\" title=\"7.15.8/\">7.15.8/</a>", index_content)
-        self.assertIn("<a href=\"-/\" title=\"-/\">-/</a>", index_content)
-        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
-        self.assertNotIn("<a href=\"7.14.5/\" title=\"7.14.5/\">7.14.5/</a>", index_content)
+        self.assertIn("<a href=\"7.15.8/index.html\" title=\"7.15.8/\">7.15.8/</a>", index_content)
+        self.assertIn("<a href=\"-/index.html\" title=\"-/\">-/</a>", index_content)
+        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertNotIn(
+            "<a href=\"7.14.5/index.html\" title=\"7.14.5/\">7.14.5/</a>",
+            index_content)
 
         product_7_15_8 = "code-frame-7.15.8"
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")


### PR DESCRIPTION
   Found that CF can not look for index.html automatically as the root
   page for a directory as httpd or nginx does, so we need to manually
   add the trailing index.html for the dir link in index.html rendering.