### PR TITLE
Fix: Make listing in index.html more compact

### DIFF
--- a/charon/cmd/command.py
+++ b/charon/cmd/command.py
@@ -153,6 +153,7 @@ def upload(
         print(traceback.format_exc())
         sys.exit(2)  # distinguish between exception and bad config or bad state
 
+
 @argument(
     "repo",
     type=str,

--- a/template/index.html.j2
+++ b/template/index.html.j2
@@ -17,15 +17,13 @@ body {
   </header>
   <hr/>
   <main>
-    <pre id="contents">
-    {% for item in index.items %}
-      {% if item.endswith("/") %}
-        <a href="{{ item }}index.html" title="{{ item }}">{{ item }}</a>
-      {% else %}
-        <a href="{{ item }}" title="{{ item }}">{{ item }}</a>
-      {% endif %}
-    {% endfor%}
-    </pre>
+    <ul style="list-style: none outside;" id="contents">
+    {% for item in index.items %}{% if item.endswith("/") %}
+        <li><a href="{{ item }}index.html" title="{{ item }}">{{ item }}</a></li>
+    {% else %}
+        <li><a href="{{ item }}" title="{{ item }}">{{ item }}</a></li>
+    {% endif %}{% endfor%}
+    </ul>
   </main>
   <hr/>
 </body>


### PR DESCRIPTION
This uses an unordered list instead of `pre` to avoid any residual problems with jinja template spacing, and sets the list style to avoid any item marker, and to place items outside the normal list indent.