### PR TITLE
Fix: sort index.html items to make folder listed before

### DIFF
--- a/charon/pkgs/indexing.py
+++ b/charon/pkgs/indexing.py
@@ -159,7 +159,7 @@ def __to_html(contents: List[str], folder: str, top_level: str) -> str:
 
 
 def __sort_index_items(items):
-    sorted_items = sorted(items)
+    sorted_items = sorted(items, key=IndexedItemsCompareKey)
     # make sure metadata is the last element
     if 'maven-metadata.xml' in sorted_items:
         sorted_items.remove('maven-metadata.xml')
@@ -202,3 +202,44 @@ class FolderLenCompareKey:
         xitems = self.obj.split("/")
         yitems = other.obj.split("/")
         return len(yitems) - len(xitems)
+
+
+class IndexedItemsCompareKey:
+    """Used as key function for indexed items sorting in index.html,
+       will make all folder listed before files.
+    """
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __lt__(self, other):
+        return self.__compare(other) < 0
+
+    def __gt__(self, other):
+        return self.__compare(other) > 0
+
+    def __le__(self, other):
+        return self.__compare(other) <= 0
+
+    def __ge__(self, other):
+        return self.__compare(other) >= 0
+
+    def __eq__(self, other):
+        return self.__compare(other) == 0
+
+    def __hash__(self) -> int:
+        return self.obj.__hash__()
+
+    def __compare(self, other) -> int:
+        origin = self.obj
+        target = other.obj
+        if origin.endswith("/") and not target.endswith("/"):
+            return -1
+        if target.endswith("/") and not origin.endswith("/"):
+            return 1
+        if origin > target:
+            return 1
+        elif origin < target:
+            return -1
+        else:
+            return 0

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,0 +1,40 @@
+"""
+Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/charon)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from charon.pkgs.indexing import FolderLenCompareKey, IndexedItemsCompareKey
+from tests.base import BaseTest
+
+
+class IndexingTest(BaseTest):
+
+    def test_folder_len_compare(self):
+        comp_class = FolderLenCompareKey
+        self.assertGreater(comp_class("org"), comp_class('org/apache'))
+        self.assertGreater(comp_class("org/"), comp_class('org/apache/'))
+        self.assertLess(comp_class("org/commons"), comp_class('org'))
+        self.assertEqual(comp_class("org/"), comp_class('org/'))
+        self.assertEqual(comp_class("org"), comp_class('commons-io'))
+        self.assertEqual(comp_class("com/redhat"), comp_class('org/commons'))
+
+    def test_index_items_compare(self):
+        comp_class = IndexedItemsCompareKey
+        self.assertLess(comp_class("apache"), comp_class('beacon'))
+        self.assertGreater(comp_class("apache"), comp_class('beacon/'))
+        self.assertEqual(comp_class("apache"), comp_class("apache"))
+        self.assertEqual(comp_class("apache/"), comp_class("apache/"))
+        self.assertLess(comp_class("apache/"), comp_class("apache"))
+        self.assertLess(comp_class("apache/"), comp_class("readme.md"))
+        self.assertLess(comp_class("apache/"), comp_class("commons-io/"))


### PR DESCRIPTION
  Found that the index.html items list mixed between folders and files.
  We need to let folders listed before files. This fix it.