### PR TITLE
Fix: Add missing digest files for maven-metadata.xml

### DIFF
--- a/charon/pkgs/pkg_utils.py
+++ b/charon/pkgs/pkg_utils.py
@@ -5,6 +5,21 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def is_metadata(file: str) -> bool:
+    return is_mvn_metadata(file) or \
+           is_npm_metadata(file) or \
+           file.endswith("index.html")
+
+
+def is_mvn_metadata(file: str) -> bool:
+    return "maven-metadata.xml" in file or \
+           "archetype-catalog.xml" in file
+
+
+def is_npm_metadata(file: str) -> bool:
+    return "package.json" in file
+
+
 def upload_post_process(failed_files: List[str], failed_metas: List[str], product_key):
     __post_process(failed_files, failed_metas, product_key, "uploaded to")
 

--- a/charon/storage.py
+++ b/charon/storage.py
@@ -19,7 +19,7 @@ from boto3 import session
 from botocore.errorfactory import ClientError
 from botocore.exceptions import HTTPClientError
 from botocore.config import Config
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 import os
 import logging
 import mimetypes
@@ -183,7 +183,7 @@ class S3Client(object):
 
     def upload_metadatas(
         self, meta_file_paths: List[str], bucket_name: str,
-        product: str, root="/", key_prefix: str = None
+        product: Optional[str], root="/", key_prefix: str = None
     ) -> Tuple[List[str], List[str]]:
         """ Upload a list of metadata files to s3 bucket. This function is very similar to
         upload_files, except:

--- a/charon/utils/files.py
+++ b/charon/utils/files.py
@@ -27,7 +27,7 @@ class HashType(Enum):
     SHA256 = 2
 
 
-def write_file(file_path: str, content: str):
+def overwrite_file(file_path: str, content: str):
     if not os.path.isfile(file_path):
         with open(file_path, mode="a", encoding="utf-8"):
             pass
@@ -64,6 +64,8 @@ def digest(file: str, hash_type=HashType.SHA1) -> str:
         hash_obj = hashlib.sha1()
     elif hash_type == HashType.SHA256:
         hash_obj = hashlib.sha256()
+    elif hash_type == HashType.MD5:
+        hash_obj = hashlib.md5()
     else:
         raise Exception("Error: Unknown hash type for digesting.")
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,7 +17,7 @@ import unittest
 import tempfile
 import os
 import shutil
-from charon.utils.files import write_file
+from charon.utils.files import overwrite_file
 from charon.config import CONFIG_FILE
 
 SHORT_TEST_PREFIX = "ga"
@@ -63,7 +63,7 @@ targets:
 
     def prepare_config(self, config_base, file_content):
         config_path = os.path.join(config_base, CONFIG_FILE)
-        write_file(config_path, file_content)
+        overwrite_file(config_path, file_content)
         if not os.path.isfile(config_path):
             self.fail("Configuration initilization failed!")
 

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -1,0 +1,79 @@
+TEST_MVN_BUCKET = "test_bucket"
+
+COMMONS_CLIENT_456_FILES = [
+    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom.sha1",
+    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar",
+    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar.sha1",
+    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom"
+]
+
+COMMONS_CLIENT_459_FILES = [
+    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.pom.sha1",
+    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar",
+    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar.sha1",
+    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.pom"
+]
+
+COMMONS_CLIENT_METAS = [
+    "org/apache/httpcomponents/httpclient/maven-metadata.xml",
+    "org/apache/httpcomponents/httpclient/maven-metadata.xml.md5",
+    "org/apache/httpcomponents/httpclient/maven-metadata.xml.sha1",
+    "org/apache/httpcomponents/httpclient/maven-metadata.xml.sha256"
+]
+
+COMMONS_LOGGING_FILES = [
+    "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar",
+    "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar.sha1",
+    "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+    "commons-logging/commons-logging/1.2/commons-logging-1.2.jar.sha1",
+    "commons-logging/commons-logging/1.2/commons-logging-1.2.pom",
+    "commons-logging/commons-logging/1.2/commons-logging-1.2.pom.sha1",
+]
+
+COMMONS_LOGGING_METAS = [
+    "commons-logging/commons-logging/maven-metadata.xml",
+    "commons-logging/commons-logging/maven-metadata.xml.md5",
+    "commons-logging/commons-logging/maven-metadata.xml.sha1",
+    "commons-logging/commons-logging/maven-metadata.xml.sha256"
+]
+
+NON_MVN_FILES = [
+    "commons-client-4.5.6/example-settings.xml",
+    "commons-client-4.5.6/licenses/gnu",
+    "commons-client-4.5.6/licenses/licenses.txt",
+    "commons-client-4.5.6/README.md",
+    "commons-client-4.5.9/example-settings.xml",
+    "commons-client-4.5.9/licenses/gnu",
+    "commons-client-4.5.9/licenses/licenses.txt",
+    "commons-client-4.5.9/README.md"
+]
+
+COMMONS_CLIENT_456_INDEXES = [
+    "index.html",
+    "org/index.html",
+    "org/apache/index.html",
+    "org/apache/httpcomponents/index.html",
+    "org/apache/httpcomponents/httpclient/index.html",
+    "org/apache/httpcomponents/httpclient/4.5.6/index.html",
+]
+
+COMMONS_CLIENT_459_INDEXES = [
+    "index.html",
+    "org/index.html",
+    "org/apache/index.html",
+    "org/apache/httpcomponents/index.html",
+    "org/apache/httpcomponents/httpclient/index.html",
+    "org/apache/httpcomponents/httpclient/4.5.9/index.html",
+]
+
+
+COMMONS_LOGGING_INDEXES = [
+    "commons-logging/index.html",
+    "commons-logging/commons-logging/index.html",
+    "commons-logging/commons-logging/1.2/index.html",
+]
+
+COMMONS_CLIENT_INDEX = "org/apache/httpcomponents/httpclient/index.html"
+COMMONS_CLIENT_456_INDEX = "org/apache/httpcomponents/httpclient/4.5.6/index.html"
+COMMONS_LOGGING_INDEX = "commons-logging/commons-logging/index.html"
+COMMONS_ROOT_INDEX = "index.html"

--- a/tests/test_maven_del.py
+++ b/tests/test_maven_del.py
@@ -2,49 +2,13 @@ from charon.pkgs.maven import handle_maven_uploading, handle_maven_del
 from charon.storage import PRODUCT_META_KEY, CHECKSUM_META_KEY
 from charon.utils.strings import remove_prefix
 from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, BaseTest
+from tests.commons import (
+    TEST_MVN_BUCKET, COMMONS_CLIENT_456_FILES, COMMONS_CLIENT_METAS,
+    COMMONS_LOGGING_FILES, COMMONS_LOGGING_METAS
+)
 from moto import mock_s3
 import boto3
 import os
-
-TEST_BUCKET = "test_bucket"
-
-COMMONS_CLIENT_456_FILES = [
-    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom.sha1",
-    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar",
-    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar.sha1",
-    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom"
-]
-
-COMMONS_CLIENT_459_FILES = [
-    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.pom.sha1",
-    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar",
-    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar.sha1",
-    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.pom"
-]
-
-COMMONS_CLIENT_META = "org/apache/httpcomponents/httpclient/maven-metadata.xml"
-
-COMMONS_LOGGING_FILES = [
-    "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar.sha1",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.jar.sha1",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.pom",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.pom.sha1",
-]
-
-COMMONS_LOGGING_META = "commons-logging/commons-logging/maven-metadata.xml"
-
-NON_MVN_FILES = [
-    "commons-client-4.5.6/example-settings.xml",
-    "commons-client-4.5.6/licenses/gnu",
-    "commons-client-4.5.6/licenses/licenses.txt",
-    "commons-client-4.5.6/README.md",
-    "commons-client-4.5.9/example-settings.xml",
-    "commons-client-4.5.9/licenses/gnu",
-    "commons-client-4.5.9/licenses/licenses.txt",
-    "commons-client-4.5.9/README.md"
-]
 
 
 @mock_s3
@@ -53,10 +17,10 @@ class MavenDeleteTest(BaseTest):
         super().setUp()
         # mock_s3 is used to generate expected content
         self.mock_s3 = self.__prepare_s3()
-        self.mock_s3.create_bucket(Bucket=TEST_BUCKET)
+        self.mock_s3.create_bucket(Bucket=TEST_MVN_BUCKET)
 
     def tearDown(self):
-        bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         try:
             bucket.objects.all().delete()
             bucket.delete()
@@ -74,30 +38,30 @@ class MavenDeleteTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir, do_index=False
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(12, len(objs))
-
         actual_files = [obj.key for obj in objs]
+        self.assertEqual(18, len(actual_files))
 
         for f in COMMONS_CLIENT_456_FILES:
             self.assertNotIn(f, actual_files)
-        self.assertIn(COMMONS_CLIENT_META, actual_files)
+        for f in COMMONS_CLIENT_METAS:
+            self.assertIn(f, actual_files)
 
         for f in COMMONS_LOGGING_FILES:
             self.assertIn(f, actual_files)
-        self.assertIn(COMMONS_LOGGING_META, actual_files)
+        for f in COMMONS_LOGGING_METAS:
+            self.assertIn(f, actual_files)
 
         for obj in objs:
             self.assertIn(CHECKSUM_META_KEY, obj.Object().metadata)
             self.assertNotEqual("", obj.Object().metadata[CHECKSUM_META_KEY].strip())
 
         product_459 = "commons-client-4.5.9"
-        meta_obj_client = test_bucket.Object(COMMONS_CLIENT_META)
-        self.assertEqual(product_459, meta_obj_client.metadata[PRODUCT_META_KEY])
+        meta_obj_client = test_bucket.Object(COMMONS_CLIENT_METAS[0])
         meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
         self.assertIn(
             "<groupId>org.apache.httpcomponents</groupId>", meta_content_client
@@ -110,8 +74,8 @@ class MavenDeleteTest(BaseTest):
         self.assertIn("<release>4.5.9</release>", meta_content_client)
         self.assertIn("<version>4.5.9</version>", meta_content_client)
 
-        meta_obj_logging = test_bucket.Object(COMMONS_LOGGING_META)
-        self.assertEqual(product_459, meta_obj_logging.metadata[PRODUCT_META_KEY])
+        meta_obj_logging = test_bucket.Object(COMMONS_LOGGING_METAS[0])
+        self.assertNotIn(PRODUCT_META_KEY, meta_obj_logging.metadata)
         meta_content_logging = str(meta_obj_logging.get()["Body"].read(), "utf-8")
         self.assertIn("<groupId>commons-logging</groupId>", meta_content_logging)
         self.assertIn("<artifactId>commons-logging</artifactId>", meta_content_logging)
@@ -122,7 +86,8 @@ class MavenDeleteTest(BaseTest):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir,
+            do_index=False
         )
 
         objs = list(test_bucket.objects.all())
@@ -139,16 +104,15 @@ class MavenDeleteTest(BaseTest):
         handle_maven_del(
             test_zip, product_456,
             ignore_patterns=[".*.sha1"],
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             dir_=self.tempdir,
             do_index=False
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(14, len(objs))
-
         actual_files = [obj.key for obj in objs]
+        self.assertEqual(20, len(actual_files))
 
         httpclient_ignored_files = [
             "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom.sha1",
@@ -201,46 +165,50 @@ class MavenDeleteTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             prefix=prefix,
             dir_=self.tempdir, do_index=False
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
         actual_files = [obj.key for obj in objs]
-        self.assertEqual(12, len(actual_files))
+        self.assertEqual(18, len(actual_files))
 
         prefix_ = remove_prefix(prefix, "/")
         PREFIXED_COMMONS_CLIENT_456_FILES = [
             os.path.join(prefix_, f) for f in COMMONS_CLIENT_456_FILES]
         for f in PREFIXED_COMMONS_CLIENT_456_FILES:
             self.assertNotIn(f, actual_files)
-        PREFIXED_COMMONS_CLIENT_META = os.path.join(prefix_, COMMONS_CLIENT_META)
-        self.assertIn(PREFIXED_COMMONS_CLIENT_META, actual_files)
+        PREFIXED_COMMONS_CLIENT_METAS = [
+            os.path.join(prefix_, f) for f in COMMONS_CLIENT_METAS]
+        for f in PREFIXED_COMMONS_CLIENT_METAS:
+            self.assertIn(f, actual_files)
 
         PREFIXED_COMMONS_LOGGING_FILES = [
             os.path.join(prefix_, f) for f in COMMONS_LOGGING_FILES]
         for f in PREFIXED_COMMONS_LOGGING_FILES:
             self.assertIn(f, actual_files)
-        PREFIXED_COMMONS_LOGGING_META = os.path.join(prefix_, COMMONS_LOGGING_META)
-        self.assertIn(PREFIXED_COMMONS_LOGGING_META, actual_files)
+        PREFIXED_COMMONS_LOGGING_METAS = [
+            os.path.join(prefix_, f) for f in COMMONS_LOGGING_METAS]
+        for f in PREFIXED_COMMONS_LOGGING_METAS:
+            self.assertIn(f, actual_files)
 
         for obj in objs:
             self.assertIn(CHECKSUM_META_KEY, obj.Object().metadata)
             self.assertNotEqual("", obj.Object().metadata[CHECKSUM_META_KEY].strip())
 
         product_459 = "commons-client-4.5.9"
-        meta_obj_client = test_bucket.Object(PREFIXED_COMMONS_CLIENT_META)
-        self.assertEqual(product_459, meta_obj_client.metadata[PRODUCT_META_KEY])
+        meta_obj_client = test_bucket.Object(PREFIXED_COMMONS_CLIENT_METAS[0])
+        self.assertNotIn(PRODUCT_META_KEY, meta_obj_client.metadata)
 
-        meta_obj_logging = test_bucket.Object(PREFIXED_COMMONS_LOGGING_META)
-        self.assertEqual(product_459, meta_obj_logging.metadata[PRODUCT_META_KEY])
+        meta_obj_logging = test_bucket.Object(PREFIXED_COMMONS_LOGGING_METAS[0])
+        self.assertNotIn(PRODUCT_META_KEY, meta_obj_logging.metadata)
 
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             prefix=prefix,
             dir_=self.tempdir,
             do_index=False
@@ -254,7 +222,7 @@ class MavenDeleteTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             prefix=prefix,
             dir_=self.tempdir,
             do_index=False
@@ -264,7 +232,7 @@ class MavenDeleteTest(BaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             prefix=prefix,
             dir_=self.tempdir,
             do_index=False

--- a/tests/test_maven_upload.py
+++ b/tests/test_maven_upload.py
@@ -1,50 +1,16 @@
 from charon.pkgs.maven import handle_maven_uploading
+from charon.pkgs.pkg_utils import is_metadata
 from charon.storage import PRODUCT_META_KEY, CHECKSUM_META_KEY
 from charon.utils.strings import remove_prefix
 from tests.base import BaseTest, SHORT_TEST_PREFIX, LONG_TEST_PREFIX
+from tests.commons import (
+    TEST_MVN_BUCKET, COMMONS_CLIENT_456_FILES, COMMONS_CLIENT_459_FILES,
+    COMMONS_CLIENT_METAS, COMMONS_LOGGING_FILES, COMMONS_LOGGING_METAS,
+    NON_MVN_FILES
+)
 from moto import mock_s3
 import boto3
 import os
-
-TEST_BUCKET = "test_bucket"
-
-COMMONS_CLIENT_456_FILES = [
-    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom.sha1",
-    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar",
-    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar.sha1",
-    "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom"
-]
-
-COMMONS_CLIENT_459_FILES = [
-    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.pom.sha1",
-    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar",
-    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar.sha1",
-    "org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.pom"
-]
-
-COMMONS_CLIENT_META = "org/apache/httpcomponents/httpclient/maven-metadata.xml"
-
-COMMONS_LOGGING_FILES = [
-    "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar.sha1",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.jar.sha1",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.pom",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.pom.sha1",
-]
-
-COMMONS_LOGGING_META = "commons-logging/commons-logging/maven-metadata.xml"
-
-NON_MVN_FILES = [
-    "commons-client-4.5.6/example-settings.xml",
-    "commons-client-4.5.6/licenses/gnu",
-    "commons-client-4.5.6/licenses/licenses.txt",
-    "commons-client-4.5.6/README.md",
-    "commons-client-4.5.9/example-settings.xml",
-    "commons-client-4.5.9/licenses/gnu",
-    "commons-client-4.5.9/licenses/licenses.txt",
-    "commons-client-4.5.9/README.md"
-]
 
 
 @mock_s3
@@ -53,10 +19,10 @@ class MavenUploadTest(BaseTest):
         super().setUp()
         # mock_s3 is used to generate expected content
         self.mock_s3 = self.__prepare_s3()
-        self.mock_s3.create_bucket(Bucket=TEST_BUCKET)
+        self.mock_s3.create_bucket(Bucket=TEST_MVN_BUCKET)
 
     def tearDown(self):
-        bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         try:
             bucket.objects.all().delete()
             bucket.delete()
@@ -72,32 +38,42 @@ class MavenUploadTest(BaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir, do_index=False
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(12, len(objs))
-
         actual_files = [obj.key for obj in objs]
+        self.assertEqual(18, len(actual_files))
 
         for f in COMMONS_CLIENT_456_FILES:
             self.assertIn(f, actual_files)
-        self.assertIn(COMMONS_CLIENT_META, actual_files)
+        for f in COMMONS_CLIENT_METAS:
+            self.assertIn(f, actual_files)
 
         for f in COMMONS_LOGGING_FILES:
             self.assertIn(f, actual_files)
-        self.assertIn(COMMONS_LOGGING_META, actual_files)
+        for f in COMMONS_LOGGING_METAS:
+            self.assertIn(f, actual_files)
 
         for f in NON_MVN_FILES:
             self.assertNotIn(f, actual_files)
 
         for obj in objs:
-            self.assertEqual(product, obj.Object().metadata[PRODUCT_META_KEY])
-            self.assertIn(CHECKSUM_META_KEY, obj.Object().metadata)
-            self.assertNotEqual("", obj.Object().metadata[CHECKSUM_META_KEY].strip())
+            file_obj = obj.Object()
+            if not is_metadata(file_obj.key):
+                self.assertEqual(product, file_obj.metadata[PRODUCT_META_KEY])
+            else:
+                self.assertNotIn(PRODUCT_META_KEY, file_obj.metadata)
+                if file_obj.key.endswith("maven-metadata.xml"):
+                    sha1_checksum = file_obj.metadata[CHECKSUM_META_KEY].strip()
+                    sha1_obj = test_bucket.Object(file_obj.key+".sha1")
+                    sha1_file_content = str(sha1_obj.get()['Body'].read(), 'utf-8')
+                    self.assertEqual(sha1_checksum, sha1_file_content)
+            self.assertIn(CHECKSUM_META_KEY, file_obj.metadata)
+            self.assertNotEqual("", file_obj.metadata[CHECKSUM_META_KEY].strip())
 
-        meta_obj_client = test_bucket.Object(COMMONS_CLIENT_META)
+        meta_obj_client = test_bucket.Object(COMMONS_CLIENT_METAS[0])
         meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
         self.assertIn(
             "<groupId>org.apache.httpcomponents</groupId>", meta_content_client
@@ -108,7 +84,7 @@ class MavenUploadTest(BaseTest):
         self.assertIn("<release>4.5.6</release>", meta_content_client)
         self.assertNotIn("<version>4.5.9</version>", meta_content_client)
 
-        meta_obj_logging = test_bucket.Object(COMMONS_LOGGING_META)
+        meta_obj_logging = test_bucket.Object(COMMONS_LOGGING_METAS[0])
         meta_content_logging = str(meta_obj_logging.get()["Body"].read(), "utf-8")
         self.assertIn("<groupId>commons-logging</groupId>", meta_content_logging)
         self.assertIn("<artifactId>commons-logging</artifactId>", meta_content_logging)
@@ -121,21 +97,21 @@ class MavenUploadTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir, do_index=False
         )
 
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir, do_index=False
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(16, len(objs))
-
         actual_files = [obj.key for obj in objs]
+        self.assertEqual(22, len(actual_files))
+
         for f in COMMONS_CLIENT_456_FILES:
             self.assertIn(f, actual_files)
             self.assertEqual(
@@ -146,16 +122,9 @@ class MavenUploadTest(BaseTest):
             self.assertEqual(
                 product_459, test_bucket.Object(f).metadata[PRODUCT_META_KEY]
             )
-        self.assertIn(COMMONS_CLIENT_META, actual_files)
+        for f in COMMONS_CLIENT_METAS:
+            self.assertIn(f, actual_files)
         product_mix = set([product_456, product_459])
-        self.assertSetEqual(
-            product_mix,
-            set(
-                test_bucket.Object(COMMONS_CLIENT_META)
-                .metadata[PRODUCT_META_KEY]
-                .split(",")
-            ),
-        )
 
         for f in COMMONS_LOGGING_FILES:
             self.assertIn(f, actual_files)
@@ -163,17 +132,10 @@ class MavenUploadTest(BaseTest):
                 product_mix,
                 set(test_bucket.Object(f).metadata[PRODUCT_META_KEY].split(",")),
             )
-        self.assertIn(COMMONS_LOGGING_META, actual_files)
-        self.assertSetEqual(
-            product_mix,
-            set(
-                test_bucket.Object(COMMONS_LOGGING_META)
-                .metadata[PRODUCT_META_KEY]
-                .split(",")
-            ),
-        )
+        for f in COMMONS_LOGGING_METAS:
+            self.assertIn(f, actual_files)
 
-        meta_obj_client = test_bucket.Object(COMMONS_CLIENT_META)
+        meta_obj_client = test_bucket.Object(COMMONS_CLIENT_METAS[0])
         meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
         self.assertIn(
             "<groupId>org.apache.httpcomponents</groupId>", meta_content_client
@@ -184,7 +146,7 @@ class MavenUploadTest(BaseTest):
         self.assertIn("<version>4.5.6</version>", meta_content_client)
         self.assertIn("<version>4.5.9</version>", meta_content_client)
 
-        meta_obj_logging = test_bucket.Object(COMMONS_LOGGING_META)
+        meta_obj_logging = test_bucket.Object(COMMONS_LOGGING_METAS[0])
         meta_content_logging = str(meta_obj_logging.get()["Body"].read(), "utf-8")
         self.assertIn("<groupId>commons-logging</groupId>", meta_content_logging)
         self.assertIn("<artifactId>commons-logging</artifactId>", meta_content_logging)
@@ -197,14 +159,13 @@ class MavenUploadTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456, [".*.sha1"],
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir, do_index=False
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(7, len(objs))
-
         actual_files = [obj.key for obj in objs]
+        self.assertEqual(13, len(actual_files))
 
         ignored_files = [
             "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom.sha1",
@@ -231,31 +192,35 @@ class MavenUploadTest(BaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             prefix=prefix,
             dir_=self.tempdir,
             do_index=False
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
         actual_files = [obj.key for obj in objs]
-        self.assertEqual(12, len(actual_files))
+        self.assertEqual(18, len(actual_files))
 
         prefix_ = remove_prefix(prefix, "/")
         PREFIXED_COMMONS_CLIENT_456_FILES = [
             os.path.join(prefix_, f) for f in COMMONS_CLIENT_456_FILES]
         for f in PREFIXED_COMMONS_CLIENT_456_FILES:
             self.assertIn(f, actual_files)
-        PREFIXED_COMMONS_CLIENT_META = os.path.join(prefix_, COMMONS_CLIENT_META)
-        self.assertIn(PREFIXED_COMMONS_CLIENT_META, actual_files)
+        PREFIXED_COMMONS_CLIENT_METAS = [
+            os.path.join(prefix_, f) for f in COMMONS_CLIENT_METAS]
+        for f in PREFIXED_COMMONS_CLIENT_METAS:
+            self.assertIn(f, actual_files)
 
         PREFIXED_COMMONS_LOGGING_FILES = [
             os.path.join(prefix_, f) for f in COMMONS_LOGGING_FILES]
         for f in PREFIXED_COMMONS_LOGGING_FILES:
             self.assertIn(f, actual_files)
-        PREFIXED_COMMONS_LOGGING_META = os.path.join(prefix_, COMMONS_LOGGING_META)
-        self.assertIn(PREFIXED_COMMONS_LOGGING_META, actual_files)
+        PREFIXED_COMMONS_LOGGING_METAS = [
+            os.path.join(prefix_, f) for f in COMMONS_LOGGING_METAS]
+        for f in PREFIXED_COMMONS_LOGGING_METAS:
+            self.assertIn(f, actual_files)
 
         PREFIXED_NON_MVN_FILES = [
             os.path.join(prefix_, f) for f in NON_MVN_FILES]
@@ -263,12 +228,16 @@ class MavenUploadTest(BaseTest):
             self.assertNotIn(f, actual_files)
 
         for obj in objs:
-            self.assertEqual(product, obj.Object().metadata[PRODUCT_META_KEY])
-            self.assertIn(CHECKSUM_META_KEY, obj.Object().metadata)
-            self.assertNotEqual("", obj.Object().metadata[CHECKSUM_META_KEY].strip())
+            file_obj = obj.Object()
+            if not is_metadata(file_obj.key):
+                self.assertEqual(product, file_obj.metadata[PRODUCT_META_KEY])
+            else:
+                self.assertNotIn(PRODUCT_META_KEY, file_obj.metadata)
+            self.assertIn(CHECKSUM_META_KEY, file_obj.metadata)
+            self.assertNotEqual("", file_obj.metadata[CHECKSUM_META_KEY].strip())
 
-        meta_obj_client = test_bucket.Object(PREFIXED_COMMONS_CLIENT_META)
+        meta_obj_client = test_bucket.Object(PREFIXED_COMMONS_CLIENT_METAS[0])
         self.assertIsNotNone(meta_obj_client)
 
-        meta_obj_logging = test_bucket.Object(PREFIXED_COMMONS_LOGGING_META)
+        meta_obj_logging = test_bucket.Object(PREFIXED_COMMONS_LOGGING_METAS[0])
         self.assertIsNotNone(meta_obj_logging)

--- a/tests/test_npm_index.py
+++ b/tests/test_npm_index.py
@@ -20,8 +20,6 @@ from moto import mock_s3
 import boto3
 import os
 
-TEST_BUCKET = "test_bucket"
-
 TEST_BUCKET = "npm_bucket"
 
 CODE_FRAME_7_14_5_INDEXES = [

--- a/tests/test_pkgs_dryrun.py
+++ b/tests/test_pkgs_dryrun.py
@@ -1,11 +1,10 @@
 from charon.pkgs.maven import handle_maven_uploading, handle_maven_del
 from charon.pkgs.npm import handle_npm_uploading, handle_npm_del
 from tests.base import BaseTest
+from tests.commons import TEST_MVN_BUCKET
 from moto import mock_s3
 import boto3
 import os
-
-TEST_BUCKET = "test_bucket"
 
 
 @mock_s3
@@ -14,10 +13,10 @@ class PkgsDryRunTest(BaseTest):
         super().setUp()
         # mock_s3 is used to generate expected content
         self.mock_s3 = self.__prepare_s3()
-        self.mock_s3.create_bucket(Bucket=TEST_BUCKET)
+        self.mock_s3.create_bucket(Bucket=TEST_MVN_BUCKET)
 
     def tearDown(self):
-        bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         try:
             bucket.objects.all().delete()
             bucket.delete()
@@ -33,12 +32,12 @@ class PkgsDryRunTest(BaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             dir_=self.tempdir,
             dry_run=True
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
         self.assertEqual(0, len(objs))
 
@@ -49,26 +48,26 @@ class PkgsDryRunTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             dir_=self.tempdir,
             dry_run=True
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(26, len(objs))
+        self.assertEqual(32, len(objs))
 
     def test_npm_upload_dry_run(self):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             dir_=self.tempdir,
             dry_run=True
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
         self.assertEqual(0, len(objs))
 
@@ -79,12 +78,12 @@ class PkgsDryRunTest(BaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET,
+            bucket_name=TEST_MVN_BUCKET,
             dir_=self.tempdir,
             dry_run=True
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
         objs = list(test_bucket.objects.all())
         self.assertEqual(11, len(objs))
 
@@ -93,25 +92,25 @@ class PkgsDryRunTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir
+            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
         )
 
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir
+            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
         )
 
     def __prepare_npm_content(self):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
-            test_tgz, product_7_14_5, bucket_name=TEST_BUCKET, dir_=self.tempdir
+            test_tgz, product_7_14_5, bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
         )
 
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
-            test_tgz, product_7_15_8, bucket_name=TEST_BUCKET, dir_=self.tempdir
+            test_tgz, product_7_15_8, bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
         )

--- a/tests/test_s3client.py
+++ b/tests/test_s3client.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from charon.storage import S3Client, PRODUCT_META_KEY, CHECKSUM_META_KEY
 from charon.utils.archive import extract_zip_all
-from charon.utils.files import write_file, read_sha1
+from charon.utils.files import overwrite_file, read_sha1
 from tests.base import BaseTest, SHORT_TEST_PREFIX
 from moto import mock_s3
 import boto3
@@ -222,7 +222,7 @@ class S3ClientTest(BaseTest):
         bucket = self.mock_s3.Bucket(MY_BUCKET)
 
         content1 = "This is foo bar 1.0 1"
-        write_file(file, content1)
+        overwrite_file(file, content1)
         sha1_1 = read_sha1(file)
         self.s3_client.upload_files(
             [file], bucket_name=MY_BUCKET, product="foo-bar-1.0", root=temp_root
@@ -239,7 +239,7 @@ class S3ClientTest(BaseTest):
         os.remove(file)
 
         content2 = "This is foo bar 1.0 2"
-        write_file(file, content2)
+        overwrite_file(file, content2)
         sha1_2 = read_sha1(file)
         self.assertNotEqual(sha1_1, sha1_2)
         self.s3_client.upload_files(
@@ -275,7 +275,7 @@ class S3ClientTest(BaseTest):
                 </versions>
             </versioning>
         </metadata>"""
-        write_file(file, content1)
+        overwrite_file(file, content1)
         sha1_1 = read_sha1(file)
         self.s3_client.upload_metadatas(
             [file], bucket_name=MY_BUCKET, product="foo-bar-1.0", root=temp_root
@@ -325,7 +325,7 @@ class S3ClientTest(BaseTest):
             </versioning>
         </metadata>
         """
-        write_file(file, content2)
+        overwrite_file(file, content2)
         sha1_2 = read_sha1(file)
         self.assertNotEqual(sha1_1, sha1_2)
         self.s3_client.upload_metadatas(


### PR DESCRIPTION
   As maven-metadata.xml is generated by charon, we need also support
   the digest files for this file, including md5, sha1 and sha256