### PR TITLE
Feat: Use separate file to record product info

### DIFF
--- a/charon/constants.py
+++ b/charon/constants.py
@@ -134,11 +134,9 @@ body {
   <hr/>
   <main>
     <ul style="list-style: none outside;" id="contents">
-    {% for item in index.items %}{% if item.endswith("/") %}
-        <li><a href="{{ item }}index.html" title="{{ item }}">{{ item }}</a></li>
-    {% else %}
+    {% for item in index.items %}
         <li><a href="{{ item }}" title="{{ item }}">{{ item }}</a></li>
-    {% endif %}{% endfor%}
+    {% endfor%}
     </ul>
   </main>
   <hr/>
@@ -175,3 +173,5 @@ body {
 </body>
 </html>
 '''
+
+PROD_INFO_SUFFIX = ".prodinfo"

--- a/charon/pkgs/npm.py
+++ b/charon/pkgs/npm.py
@@ -113,7 +113,7 @@ def handle_npm_uploading(
         _, _failed_metas = client.upload_metadatas(
             meta_file_paths=[meta_files[META_FILE_GEN_KEY]],
             bucket_name=bucket,
-            product=product,
+            product=None,
             root=target_dir,
             key_prefix=prefix_
         )
@@ -189,7 +189,7 @@ def handle_npm_del(
         all_meta_files.append(file)
     client.delete_files(
         file_paths=all_meta_files, bucket_name=bucket,
-        product=product, root=target_dir, key_prefix=prefix_
+        product=None, root=target_dir, key_prefix=prefix_
     )
     failed_metas = []
     if META_FILE_GEN_KEY in meta_files:

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -1,5 +1,5 @@
 # For maven
-TEST_MVN_BUCKET = "test_bucket"
+TEST_BUCKET = "test_bucket"
 COMMONS_CLIENT_456_FILES = [
     "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom.sha1",
     "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar",
@@ -49,6 +49,20 @@ NON_MVN_FILES = [
     "commons-client-4.5.9/licenses/licenses.txt",
     "commons-client-4.5.9/README.md"
 ]
+COMMONS_CLIENT_456_MVN_NUM = (
+    len(COMMONS_CLIENT_456_FILES) +
+    len(COMMONS_LOGGING_FILES))
+COMMONS_CLIENT_459_MVN_NUM = (
+    len(COMMONS_CLIENT_459_FILES) +
+    len(COMMONS_LOGGING_FILES))
+COMMONS_CLIENT_MVN_NUM = (
+    len(COMMONS_CLIENT_456_FILES) +
+    len(COMMONS_CLIENT_459_FILES) +
+    len(COMMONS_LOGGING_FILES))
+COMMONS_CLIENT_META_NUM = (
+    len(COMMONS_CLIENT_METAS) +
+    len(COMMONS_LOGGING_METAS) +
+    len(ARCHETYPE_CATALOG_FILES))
 # For maven indexes
 COMMONS_CLIENT_456_INDEXES = [
     "index.html",

--- a/tests/test_maven_index.py
+++ b/tests/test_maven_index.py
@@ -13,54 +13,37 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from charon.constants import PROD_INFO_SUFFIX
 from charon.pkgs.maven import handle_maven_uploading, handle_maven_del
-from charon.pkgs.pkg_utils import is_metadata
-from charon.storage import CHECKSUM_META_KEY, PRODUCT_META_KEY
+from charon.storage import CHECKSUM_META_KEY
 from charon.utils.strings import remove_prefix
-from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, BaseTest
+from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, PackageBaseTest
 from tests.commons import (
-    TEST_MVN_BUCKET, COMMONS_CLIENT_456_INDEXES, COMMONS_CLIENT_459_INDEXES,
+    TEST_BUCKET, COMMONS_CLIENT_456_INDEXES, COMMONS_CLIENT_459_INDEXES,
     COMMONS_LOGGING_INDEXES, COMMONS_CLIENT_INDEX, COMMONS_CLIENT_456_INDEX,
     COMMONS_LOGGING_INDEX, COMMONS_ROOT_INDEX
 )
 from moto import mock_s3
-import boto3
 import os
 
 
 @mock_s3
-class MavenFileIndexTest(BaseTest):
-    def setUp(self):
-        super().setUp()
-        # mock_s3 is used to generate expected content
-        self.mock_s3 = self.__prepare_s3()
-        self.mock_s3.create_bucket(Bucket=TEST_MVN_BUCKET)
-
-    def tearDown(self):
-        bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
-        try:
-            bucket.objects.all().delete()
-            bucket.delete()
-        except ValueError:
-            pass
-        super().tearDown()
-
-    def __prepare_s3(self):
-        return boto3.resource('s3')
+class MavenFileIndexTest(PackageBaseTest):
 
     def test_uploading_index(self):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             dir_=self.tempdir
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
         actual_files = [obj.key for obj in objs]
-        self.assertEqual(31, len(actual_files))
+
+        self.assertEqual(41, len(actual_files))
 
         for f in COMMONS_LOGGING_INDEXES:
             self.assertIn(f, actual_files)
@@ -68,79 +51,72 @@ class MavenFileIndexTest(BaseTest):
         for f in COMMONS_CLIENT_456_INDEXES:
             self.assertIn(f, actual_files)
 
-        for obj in objs:
-            file_obj = obj.Object()
-            if not is_metadata(file_obj.key):
-                self.assertEqual(product, file_obj.metadata[PRODUCT_META_KEY])
-            else:
-                self.assertNotIn(PRODUCT_META_KEY, file_obj.metadata)
-            self.assertIn(CHECKSUM_META_KEY, file_obj.metadata)
-            self.assertNotEqual("", file_obj.metadata[CHECKSUM_META_KEY].strip())
+        self.check_content(objs, [product])
 
         indedx_obj = test_bucket.Object(COMMONS_CLIENT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"4.5.6/index.html\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content
         )
-        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_ROOT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"org/index.html\" title=\"org/\">org/</a>", index_content)
+        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
         self.assertIn(
-            "<a href=\"commons-logging/index.html\" "
+            "<a href=\"commons-logging/\" "
             "title=\"commons-logging/\">commons-logging/</a>",
             index_content
         )
-        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
     def test_overlap_upload_index(self):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
-            test_zip, product_456, bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
+            test_zip, product_456, bucket_name=TEST_BUCKET, dir_=self.tempdir
         )
 
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             dir_=self.tempdir
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(36, len(objs))
+        self.assertEqual(50, len(objs))
 
         indedx_obj = test_bucket.Object(COMMONS_CLIENT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"4.5.6/index.html\" title=\"4.5.6/\">4.5.6/</a>", index_content)
-        self.assertIn("<a href=\"4.5.9/index.html\" title=\"4.5.9/\">4.5.9/</a>", index_content)
+        self.assertIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertIn("<a href=\"4.5.9/\" title=\"4.5.9/\">4.5.9/</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content)
-        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_LOGGING_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"1.2/index.html\" title=\"1.2/\">1.2/</a>", index_content)
+        self.assertIn("<a href=\"1.2/\" title=\"1.2/\">1.2/</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content)
-        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_ROOT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"org/index.html\" title=\"org/\">org/</a>", index_content)
+        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
         self.assertIn(
-            "<a href=\"commons-logging/index.html\" "
+            "<a href=\"commons-logging/\" "
             "title=\"commons-logging/\">commons-logging/</a>",
             index_content
         )
-        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
     def test_upload_index_with_short_prefix(self):
         self.__test_upload_index_with_prefix(SHORT_TEST_PREFIX)
@@ -156,15 +132,15 @@ class MavenFileIndexTest(BaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             dir_=self.tempdir,
             prefix=prefix
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
         actual_files = [obj.key for obj in objs]
-        self.assertEqual(31, len(actual_files))
+        self.assertEqual(41, len(actual_files))
 
         prefix_ = remove_prefix(prefix, "/")
         PREFIXED_LOGGING_INDEXES = [
@@ -179,33 +155,26 @@ class MavenFileIndexTest(BaseTest):
         for f in PREFIXED_456_INDEXES:
             self.assertIn(f, actual_files)
 
-        for obj in objs:
-            file_obj = obj.Object()
-            if not is_metadata(file_obj.key):
-                self.assertEqual(product, file_obj.metadata[PRODUCT_META_KEY])
-            else:
-                self.assertNotIn(PRODUCT_META_KEY, file_obj.metadata)
-            self.assertIn(CHECKSUM_META_KEY, file_obj.metadata)
-            self.assertNotEqual("", file_obj.metadata[CHECKSUM_META_KEY].strip())
+        self.check_content(objs, [product])
 
         indedx_obj = test_bucket.Object(os.path.join(prefix_, COMMONS_CLIENT_INDEX))
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"4.5.6/index.html\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content
         )
-        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
         indedx_obj = test_bucket.Object(os.path.join(prefix_, COMMONS_ROOT_INDEX))
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"org/index.html\" title=\"org/\">org/</a>", index_content)
+        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
         self.assertIn(
-            "<a href=\"commons-logging/index.html\" "
+            "<a href=\"commons-logging/\" "
             "title=\"commons-logging/\">commons-logging/</a>",
             index_content
         )
-        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
     def test_deletion_index(self):
         self.__prepare_content()
@@ -214,14 +183,14 @@ class MavenFileIndexTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             dir_=self.tempdir
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
         actual_files = [obj.key for obj in objs]
-        self.assertEqual(31, len(actual_files))
+        self.assertEqual(41, len(actual_files))
 
         for assert_file in COMMONS_CLIENT_459_INDEXES:
             self.assertIn(assert_file, actual_files)
@@ -232,33 +201,34 @@ class MavenFileIndexTest(BaseTest):
         self.assertNotIn(COMMONS_CLIENT_456_INDEX, actual_files)
 
         for obj in objs:
-            file_obj = obj.Object()
-            self.assertIn(CHECKSUM_META_KEY, file_obj.metadata)
-            self.assertNotEqual("", file_obj.metadata[CHECKSUM_META_KEY].strip())
+            if not obj.key.endswith(PROD_INFO_SUFFIX):
+                file_obj = obj.Object()
+                self.assertIn(CHECKSUM_META_KEY, file_obj.metadata)
+                self.assertNotEqual("", file_obj.metadata[CHECKSUM_META_KEY].strip())
 
         indedx_obj = test_bucket.Object(COMMONS_CLIENT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"4.5.9/index.html\" title=\"4.5.9/\">4.5.9/</a>", index_content)
-        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"4.5.9/\" title=\"4.5.9/\">4.5.9/</a>", index_content)
+        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content)
-        self.assertNotIn("<a href=\"4.5.6/index.html\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertNotIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
 
         indedx_obj = test_bucket.Object(COMMONS_ROOT_INDEX)
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"org/index.html\" title=\"org/\">org/</a>", index_content)
+        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
         self.assertIn(
-            "<a href=\"commons-logging/index.html\" "
+            "<a href=\"commons-logging/\" "
             "title=\"commons-logging/\">commons-logging/</a>",
             index_content
         )
-        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
         product_459 = "commons-client-4.5.9"
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
-            test_zip, product_459, bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
+            test_zip, product_459, bucket_name=TEST_BUCKET, dir_=self.tempdir
         )
 
         objs = list(test_bucket.objects.all())
@@ -280,15 +250,16 @@ class MavenFileIndexTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             prefix=prefix,
             dir_=self.tempdir
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        product_459 = "commons-client-4.5.9"
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
         actual_files = [obj.key for obj in objs]
-        self.assertEqual(31, len(actual_files))
+        self.assertEqual(41, len(actual_files))
 
         prefix_ = remove_prefix(prefix, "/")
         PREFIXED_459_INDEXES = [os.path.join(prefix_, i) for i in COMMONS_CLIENT_459_INDEXES]
@@ -301,39 +272,31 @@ class MavenFileIndexTest(BaseTest):
 
         self.assertNotIn(os.path.join(prefix_, COMMONS_CLIENT_456_INDEX), actual_files)
 
-        for obj in objs:
-            file_obj = obj.Object()
-            if not is_metadata(file_obj.key):
-                self.assertIn(PRODUCT_META_KEY, file_obj.metadata)
-            else:
-                self.assertNotIn(PRODUCT_META_KEY, file_obj.metadata)
-            self.assertIn(CHECKSUM_META_KEY, file_obj.metadata)
-            self.assertNotEqual("", file_obj.metadata[CHECKSUM_META_KEY].strip())
+        self.check_content(objs, [product_459])
 
         indedx_obj = test_bucket.Object(os.path.join(prefix_, COMMONS_CLIENT_INDEX))
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"4.5.9/index.html\" title=\"4.5.9/\">4.5.9/</a>", index_content)
-        self.assertIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertIn("<a href=\"4.5.9/\" title=\"4.5.9/\">4.5.9/</a>", index_content)
+        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
         self.assertIn(
             "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
             index_content)
-        self.assertNotIn("<a href=\"4.5.6/index.html\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertNotIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
 
         indedx_obj = test_bucket.Object(os.path.join(prefix_, COMMONS_ROOT_INDEX))
         index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
-        self.assertIn("<a href=\"org/index.html\" title=\"org/\">org/</a>", index_content)
+        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
         self.assertIn(
-            "<a href=\"commons-logging/index.html\" "
+            "<a href=\"commons-logging/\" "
             "title=\"commons-logging/\">commons-logging/</a>",
             index_content
         )
-        self.assertNotIn("<a href=\"../index.html\" title=\"../\">../</a>", index_content)
+        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
 
-        product_459 = "commons-client-4.5.9"
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
             test_zip, product_459,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             prefix=prefix,
             dir_=self.tempdir
         )
@@ -346,7 +309,7 @@ class MavenFileIndexTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             prefix=prefix,
             dir_=self.tempdir
         )
@@ -355,7 +318,7 @@ class MavenFileIndexTest(BaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             prefix=prefix,
             dir_=self.tempdir
         )

--- a/tests/test_npm_upload.py
+++ b/tests/test_npm_upload.py
@@ -15,36 +15,21 @@ limitations under the License.
 """
 import os
 
-import boto3
 from moto import mock_s3
 
 from charon.pkgs.npm import handle_npm_uploading
-from charon.storage import PRODUCT_META_KEY, CHECKSUM_META_KEY
-from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, BaseTest
+from charon.pkgs.pkg_utils import is_metadata
+from charon.storage import CHECKSUM_META_KEY
+from charon.constants import PROD_INFO_SUFFIX
+from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, PackageBaseTest
 from tests.commons import (
-    TEST_NPM_BUCKET, CODE_FRAME_7_14_5_FILES,
+    TEST_BUCKET, CODE_FRAME_7_14_5_FILES,
     CODE_FRAME_7_15_8_FILES, CODE_FRAME_META
 )
 
 
 @mock_s3
-class NPMUploadTest(BaseTest):
-    def setUp(self):
-        super().setUp()
-        self.mock_s3 = self.__prepare_s3()
-        self.mock_s3.create_bucket(Bucket=TEST_NPM_BUCKET)
-
-    def tearDown(self):
-        bucket = self.mock_s3.Bucket(TEST_NPM_BUCKET)
-        try:
-            bucket.objects.all().delete()
-            bucket.delete()
-        except ValueError:
-            pass
-        super().tearDown()
-
-    def __prepare_s3(self):
-        return boto3.resource("s3")
+class NPMUploadTest(PackageBaseTest):
 
     def test_npm_upload(self):
         self.__test_prefix()
@@ -62,39 +47,26 @@ class NPMUploadTest(BaseTest):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
-            test_tgz, product_7_14_5, bucket_name=TEST_NPM_BUCKET, dir_=self.tempdir, do_index=False
+            test_tgz, product_7_14_5, bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
         )
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
-            test_tgz, product_7_15_8, bucket_name=TEST_NPM_BUCKET, dir_=self.tempdir, do_index=False
+            test_tgz, product_7_15_8, bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
         )
-        test_bucket = self.mock_s3.Bucket(TEST_NPM_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(5, len(objs))
-
         actual_files = [obj.key for obj in objs]
+        self.assertEqual(9, len(actual_files))
 
         for f in CODE_FRAME_7_14_5_FILES:
             self.assertIn(f, actual_files)
-            self.assertEqual(
-                product_7_14_5, test_bucket.Object(f).metadata[PRODUCT_META_KEY]
-            )
+            self.check_product(f, [product_7_14_5])
         for f in CODE_FRAME_7_15_8_FILES:
             self.assertIn(f, actual_files)
-            self.assertEqual(
-                product_7_15_8, test_bucket.Object(f).metadata[PRODUCT_META_KEY]
-            )
+            self.check_product(f, [product_7_15_8])
         self.assertIn(CODE_FRAME_META, actual_files)
-        product_mix = set([product_7_14_5, product_7_15_8])
-        self.assertSetEqual(
-            product_mix,
-            set(
-                test_bucket.Object(CODE_FRAME_META)
-                .metadata[PRODUCT_META_KEY]
-                .split(",")
-            ),
-        )
+        # self.check_product(CODE_FRAME_META, product_mix)
 
         meta_obj_client = test_bucket.Object(CODE_FRAME_META)
         meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
@@ -116,14 +88,14 @@ class NPMUploadTest(BaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_NPM_BUCKET, prefix=prefix,
+            bucket_name=TEST_BUCKET, prefix=prefix,
             dir_=self.tempdir, do_index=False
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_NPM_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
         actual_files = [obj.key for obj in objs]
-        self.assertEqual(3, len(actual_files))
+        self.assertEqual(5, len(actual_files))
 
         PREFIXED_7145_FILES = CODE_FRAME_7_14_5_FILES
         PREFIXED_FRAME_META = CODE_FRAME_META
@@ -136,10 +108,13 @@ class NPMUploadTest(BaseTest):
             self.assertIn(f, actual_files)
         self.assertIn(PREFIXED_FRAME_META, actual_files)
 
-        for obj in objs:
-            self.assertEqual(product_7_14_5, obj.Object().metadata[PRODUCT_META_KEY])
-            self.assertIn(CHECKSUM_META_KEY, obj.Object().metadata)
-            self.assertNotEqual("", obj.Object().metadata[CHECKSUM_META_KEY].strip())
+        for o in objs:
+            if not o.key.endswith(PROD_INFO_SUFFIX):
+                obj = o.Object()
+                if not is_metadata(o.key):
+                    self.check_product(o.key, [product_7_14_5])
+                self.assertIn(CHECKSUM_META_KEY, obj.metadata)
+                self.assertNotEqual("", obj.metadata[CHECKSUM_META_KEY].strip())
 
         meta_obj_client = test_bucket.Object(PREFIXED_FRAME_META)
         meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")

--- a/tests/test_pkgs_dryrun.py
+++ b/tests/test_pkgs_dryrun.py
@@ -1,43 +1,39 @@
+"""
+Copyright (C) 2021 Red Hat, Inc. (https://github.com/Commonjava/charon)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 from charon.pkgs.maven import handle_maven_uploading, handle_maven_del
 from charon.pkgs.npm import handle_npm_uploading, handle_npm_del
-from tests.base import BaseTest
-from tests.commons import TEST_MVN_BUCKET
+from tests.base import PackageBaseTest
+from tests.commons import TEST_BUCKET
 from moto import mock_s3
-import boto3
 import os
 
 
 @mock_s3
-class PkgsDryRunTest(BaseTest):
-    def setUp(self):
-        super().setUp()
-        # mock_s3 is used to generate expected content
-        self.mock_s3 = self.__prepare_s3()
-        self.mock_s3.create_bucket(Bucket=TEST_MVN_BUCKET)
-
-    def tearDown(self):
-        bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
-        try:
-            bucket.objects.all().delete()
-            bucket.delete()
-        except ValueError:
-            pass
-        super().tearDown()
-
-    def __prepare_s3(self):
-        return boto3.resource('s3')
-
+class PkgsDryRunTest(PackageBaseTest):
     def test_maven_upload_dry_run(self):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             dir_=self.tempdir,
             dry_run=True
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
         self.assertEqual(0, len(objs))
 
@@ -48,26 +44,26 @@ class PkgsDryRunTest(BaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             dir_=self.tempdir,
             dry_run=True
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(36, len(objs))
+        self.assertEqual(50, len(objs))
 
     def test_npm_upload_dry_run(self):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             dir_=self.tempdir,
             dry_run=True
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
         self.assertEqual(0, len(objs))
 
@@ -78,39 +74,39 @@ class PkgsDryRunTest(BaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_MVN_BUCKET,
+            bucket_name=TEST_BUCKET,
             dir_=self.tempdir,
             dry_run=True
         )
 
-        test_bucket = self.mock_s3.Bucket(TEST_MVN_BUCKET)
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
-        self.assertEqual(7, len(objs))
+        self.assertEqual(11, len(objs))
 
     def __prepare_maven_content(self):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
+            bucket_name=TEST_BUCKET, dir_=self.tempdir
         )
 
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
+            bucket_name=TEST_BUCKET, dir_=self.tempdir
         )
 
     def __prepare_npm_content(self):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
-            test_tgz, product_7_14_5, bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
+            test_tgz, product_7_14_5, bucket_name=TEST_BUCKET, dir_=self.tempdir
         )
 
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
-            test_tgz, product_7_15_8, bucket_name=TEST_MVN_BUCKET, dir_=self.tempdir
+            test_tgz, product_7_15_8, bucket_name=TEST_BUCKET, dir_=self.tempdir
         )


### PR DESCRIPTION
   We found that AWS file metadata has length limitation, which means
not suitable to store long information like products info. So we need to
use a new file *.prodinfo for each uploaded files. Rules:
   * Only product tarball valid files should contain this prodinfo file
   * Metadta files like maven-metadata or npm package leveled
     package.json or index files will not have this prodinfo.