### PR TITLE
Feat: multi-targets support

### DIFF
--- a/charon/cmd/command.py
+++ b/charon/cmd/command.py
@@ -151,17 +151,18 @@ def upload(
         manifest_bucket_name = conf.get_manifest_bucket()
         if npm_archive_type != NpmArchiveType.NOT_NPM:
             logger.info("This is a npm archive")
-            tmp_dir = handle_npm_uploading(
+            tmp_dir, succeeded = handle_npm_uploading(
                 archive_path,
                 product_key,
-                bucket_name=aws_bucket,
-                prefix=prefix_,
+                target=(aws_bucket, prefix_),
                 aws_profile=aws_profile,
                 dir_=work_dir,
                 dry_run=dryrun,
-                target=target,
+                manifest_folder=target,
                 manifest_bucket_name=manifest_bucket_name
             )
+            if not succeeded:
+                sys.exit(1)
         else:
             ignore_patterns_list = None
             if ignore_patterns:
@@ -169,19 +170,20 @@ def upload(
             else:
                 ignore_patterns_list = __get_ignore_patterns(conf)
             logger.info("This is a maven archive")
-            tmp_dir = handle_maven_uploading(
+            tmp_dir, succeeded = handle_maven_uploading(
                 archive_path,
                 product_key,
                 ignore_patterns_list,
                 root=root_path,
-                bucket_name=aws_bucket,
+                targets=[(aws_bucket, prefix_)],
                 aws_profile=aws_profile,
-                prefix=prefix_,
                 dir_=work_dir,
                 dry_run=dryrun,
-                target=target,
+                manifest_folder=target,
                 manifest_bucket_name=manifest_bucket_name
             )
+            if not succeeded:
+                sys.exit(1)
     except Exception:
         print(traceback.format_exc())
         sys.exit(2)  # distinguish between exception and bad config or bad state
@@ -309,17 +311,18 @@ def delete(
         manifest_bucket_name = conf.get_manifest_bucket()
         if npm_archive_type != NpmArchiveType.NOT_NPM:
             logger.info("This is a npm archive")
-            tmp_dir = handle_npm_del(
+            tmp_dir, succeeded = handle_npm_del(
                 archive_path,
                 product_key,
-                bucket_name=aws_bucket,
-                prefix=prefix_,
+                target=(aws_bucket, prefix_),
                 aws_profile=aws_profile,
                 dir_=work_dir,
                 dry_run=dryrun,
-                target=target,
+                manifest_folder=target,
                 manifest_bucket_name=manifest_bucket_name
             )
+            if not succeeded:
+                sys.exit(1)
         else:
             ignore_patterns_list = None
             if ignore_patterns:
@@ -327,19 +330,20 @@ def delete(
             else:
                 ignore_patterns_list = __get_ignore_patterns(conf)
             logger.info("This is a maven archive")
-            tmp_dir = handle_maven_del(
+            tmp_dir, succeeded = handle_maven_del(
                 archive_path,
                 product_key,
                 ignore_patterns_list,
                 root=root_path,
-                bucket_name=aws_bucket,
+                targets=[(aws_bucket, prefix_)],
                 aws_profile=aws_profile,
-                prefix=prefix_,
                 dir_=work_dir,
                 dry_run=dryrun,
-                target=target,
+                manifest_folder=target,
                 manifest_bucket_name=manifest_bucket_name
             )
+            if not succeeded:
+                sys.exit(1)
     except Exception:
         print(traceback.format_exc())
         sys.exit(2)  # distinguish between exception and bad config or bad state

--- a/charon/cmd/command.py
+++ b/charon/cmd/command.py
@@ -175,11 +175,10 @@ def upload(
                 product_key,
                 ignore_patterns_list,
                 root=root_path,
-                targets=[(aws_bucket, prefix_)],
+                targets=[(target, aws_bucket, prefix_)],
                 aws_profile=aws_profile,
                 dir_=work_dir,
                 dry_run=dryrun,
-                manifest_folder=target,
                 manifest_bucket_name=manifest_bucket_name
             )
             if not succeeded:
@@ -335,11 +334,10 @@ def delete(
                 product_key,
                 ignore_patterns_list,
                 root=root_path,
-                targets=[(aws_bucket, prefix_)],
+                targets=[(target, aws_bucket, prefix_)],
                 aws_profile=aws_profile,
                 dir_=work_dir,
                 dry_run=dryrun,
-                manifest_folder=target,
                 manifest_bucket_name=manifest_bucket_name
             )
             if not succeeded:

--- a/charon/pkgs/indexing.py
+++ b/charon/pkgs/indexing.py
@@ -127,10 +127,9 @@ def __generate_index_html(
             removed_index = os.path.join(top_level, folder_, "index.html")
         s3_client.delete_files(
             file_paths=[removed_index],
-            bucket_name=bucket,
+            target=(bucket, prefix),
             product=None,
-            root=top_level,
-            key_prefix=prefix
+            root=top_level
         )
     elif len(contents) >= 1:
         real_contents = []

--- a/charon/pkgs/pkg_utils.py
+++ b/charon/pkgs/pkg_utils.py
@@ -1,5 +1,4 @@
 from typing import List
-import sys
 import logging
 
 logger = logging.getLogger(__name__)
@@ -20,33 +19,40 @@ def is_npm_metadata(file: str) -> bool:
     return "package.json" in file
 
 
-def upload_post_process(failed_files: List[str], failed_metas: List[str], product_key):
-    __post_process(failed_files, failed_metas, product_key, "uploaded to")
+def upload_post_process(
+    failed_files: List[str], failed_metas: List[str], product_key, bucket=None
+):
+    __post_process(failed_files, failed_metas, product_key, "uploaded to", bucket)
 
 
-def rollback_post_process(failed_files: List[str], failed_metas: List[str], product_key):
-    __post_process(failed_files, failed_metas, product_key, "rolled back from")
+def rollback_post_process(
+    failed_files: List[str], failed_metas: List[str], product_key, bucket=None
+):
+    __post_process(failed_files, failed_metas, product_key, "rolled back from", bucket)
 
 
 def __post_process(
     failed_files: List[str],
     failed_metas: List[str],
     product_key: str,
-    operation: str
+    operation: str,
+    bucket: str = None
 ):
     if len(failed_files) == 0 and len(failed_metas) == 0:
-        logger.info("Product release is successfully %s "
-                    " %s Ronda service.", operation, product_key)
+        logger.info("Product release %s is successfully %s "
+                    "Ronda service in bucket %s",
+                    product_key, operation, bucket)
     else:
         total = len(failed_files) + len(failed_metas)
-        logger.error("%d file(s) occur errors/warnings, please see errors.log for details.", total)
-        logger.error("Product release %s is %s Ronda "
-                     "service, but has some failures as below:",
-                     product_key, operation)
+        logger.error("%d file(s) occur errors/warnings in bucket %s, "
+                     "please see errors.log for details.",
+                     bucket, total)
+        logger.error("Product release %s is %s Ronda service in bucket %s, "
+                     "but has some failures as below:",
+                     product_key, operation, bucket)
         if len(failed_files) > 0:
             logger.error("Failed files: \n%s",
                          failed_files)
         if len(failed_metas) > 0:
             logger.error("Failed metadata files: \n%s",
                          failed_metas)
-        sys.exit(1)

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -49,20 +49,20 @@ NON_MVN_FILES = [
     "commons-client-4.5.9/licenses/licenses.txt",
     "commons-client-4.5.9/README.md"
 ]
-COMMONS_CLIENT_456_MVN_NUM = (
-    len(COMMONS_CLIENT_456_FILES) +
-    len(COMMONS_LOGGING_FILES))
-COMMONS_CLIENT_459_MVN_NUM = (
-    len(COMMONS_CLIENT_459_FILES) +
-    len(COMMONS_LOGGING_FILES))
-COMMONS_CLIENT_MVN_NUM = (
-    len(COMMONS_CLIENT_456_FILES) +
-    len(COMMONS_CLIENT_459_FILES) +
-    len(COMMONS_LOGGING_FILES))
-COMMONS_CLIENT_META_NUM = (
-    len(COMMONS_CLIENT_METAS) +
-    len(COMMONS_LOGGING_METAS) +
-    len(ARCHETYPE_CATALOG_FILES))
+COMMONS_CLIENT_456_MVN_NUM = \
+    len(COMMONS_CLIENT_456_FILES) + \
+    len(COMMONS_LOGGING_FILES)
+COMMONS_CLIENT_459_MVN_NUM = \
+    len(COMMONS_CLIENT_459_FILES) + \
+    len(COMMONS_LOGGING_FILES)
+COMMONS_CLIENT_MVN_NUM = \
+    len(COMMONS_CLIENT_456_FILES) + \
+    len(COMMONS_CLIENT_459_FILES) + \
+    len(COMMONS_LOGGING_FILES)
+COMMONS_CLIENT_META_NUM = \
+    len(COMMONS_CLIENT_METAS) + \
+    len(COMMONS_LOGGING_METAS) + \
+    len(ARCHETYPE_CATALOG_FILES)
 # For maven indexes
 COMMONS_CLIENT_456_INDEXES = [
     "index.html",
@@ -120,3 +120,6 @@ TEST_MANIFEST_BUCKET = "test_manifest_bucket"
 TEST_TARGET = "stage"
 COMMONS_CLIENT_456_MANIFEST = "stage-charon-metadata/commons-client-4.5.6.txt"
 CODE_FRAME_7_14_5_MANIFEST = "stage-charon-metadata/code-frame-7.14.5.txt"
+
+# For multi targets support
+TEST_BUCKET_2 = "test_bucket_2"

--- a/tests/test_manifest_del.py
+++ b/tests/test_manifest_del.py
@@ -62,10 +62,9 @@ class ManifestDeleteTest(PackageBaseTest):
         product = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product,
-            target=(TEST_BUCKET, None),
+            targets=[(TEST_TARGET, TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
         uploaded_manifest = list(self.test_manifest_bucket.objects.all())
@@ -88,9 +87,8 @@ class ManifestDeleteTest(PackageBaseTest):
         product = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product,
-            target=(TEST_BUCKET, None),
+            targets=[(TEST_TARGET, TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )

--- a/tests/test_manifest_del.py
+++ b/tests/test_manifest_del.py
@@ -41,10 +41,9 @@ class ManifestDeleteTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(TEST_TARGET, TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
         uploaded_manifest = list(self.test_manifest_bucket.objects.all())
@@ -78,10 +77,9 @@ class ManifestDeleteTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(TEST_TARGET, TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
 

--- a/tests/test_manifest_del.py
+++ b/tests/test_manifest_del.py
@@ -41,10 +41,10 @@ class ManifestDeleteTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            target=TEST_TARGET,
+            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
         uploaded_manifest = list(self.test_manifest_bucket.objects.all())
@@ -63,10 +63,10 @@ class ManifestDeleteTest(PackageBaseTest):
         product = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product,
-            bucket_name=TEST_BUCKET,
+            target=(TEST_BUCKET, None),
             dir_=self.tempdir,
             do_index=False,
-            target=TEST_TARGET,
+            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
         uploaded_manifest = list(self.test_manifest_bucket.objects.all())
@@ -78,10 +78,10 @@ class ManifestDeleteTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            target=TEST_TARGET,
+            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
 
@@ -90,9 +90,9 @@ class ManifestDeleteTest(PackageBaseTest):
         product = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product,
-            bucket_name=TEST_BUCKET,
+            target=(TEST_BUCKET, None),
             dir_=self.tempdir,
             do_index=False,
-            target=TEST_TARGET,
+            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )

--- a/tests/test_manifest_upload.py
+++ b/tests/test_manifest_upload.py
@@ -35,10 +35,10 @@ class ManifestUploadTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            target=TEST_TARGET,
+            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
 
@@ -66,10 +66,10 @@ class ManifestUploadTest(PackageBaseTest):
         product = "code-frame-7.14.5"
         handle_npm_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
+            target=(TEST_BUCKET, None),
             dir_=self.tempdir,
             do_index=False,
-            target=TEST_TARGET,
+            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
 

--- a/tests/test_manifest_upload.py
+++ b/tests/test_manifest_upload.py
@@ -35,10 +35,9 @@ class ManifestUploadTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(TEST_TARGET, TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
 

--- a/tests/test_manifest_upload.py
+++ b/tests/test_manifest_upload.py
@@ -65,10 +65,9 @@ class ManifestUploadTest(PackageBaseTest):
         product = "code-frame-7.14.5"
         handle_npm_uploading(
             test_zip, product,
-            target=(TEST_BUCKET, None),
+            targets=[(TEST_TARGET, TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False,
-            manifest_folder=TEST_TARGET,
             manifest_bucket_name=TEST_MANIFEST_BUCKET
         )
 

--- a/tests/test_maven_del.py
+++ b/tests/test_maven_del.py
@@ -53,7 +53,7 @@ class MavenDeleteTest(PackageBaseTest):
         handle_maven_del(
             test_zip, product_456,
             ignore_patterns=[".*.sha1"],
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False
         )
@@ -102,8 +102,7 @@ class MavenDeleteTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir, do_index=False
         )
 
@@ -177,8 +176,7 @@ class MavenDeleteTest(PackageBaseTest):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir,
             do_index=False
         )
@@ -191,8 +189,7 @@ class MavenDeleteTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir,
             do_index=False
         )
@@ -201,8 +198,7 @@ class MavenDeleteTest(PackageBaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir,
             do_index=False
         )

--- a/tests/test_maven_del.py
+++ b/tests/test_maven_del.py
@@ -53,7 +53,7 @@ class MavenDeleteTest(PackageBaseTest):
         handle_maven_del(
             test_zip, product_456,
             ignore_patterns=[".*.sha1"],
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir,
             do_index=False
         )
@@ -102,7 +102,7 @@ class MavenDeleteTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir, do_index=False
         )
 
@@ -176,7 +176,7 @@ class MavenDeleteTest(PackageBaseTest):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
             test_zip, product_459,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir,
             do_index=False
         )
@@ -189,7 +189,7 @@ class MavenDeleteTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir,
             do_index=False
         )
@@ -198,7 +198,7 @@ class MavenDeleteTest(PackageBaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir,
             do_index=False
         )

--- a/tests/test_maven_del_multi_tgts.py
+++ b/tests/test_maven_del_multi_tgts.py
@@ -1,0 +1,273 @@
+"""
+Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/charon)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from charon.pkgs.maven import handle_maven_uploading, handle_maven_del
+from charon.storage import PRODUCT_META_KEY, CHECKSUM_META_KEY
+from charon.utils.strings import remove_prefix
+from charon.constants import PROD_INFO_SUFFIX
+from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, PackageBaseTest
+from tests.commons import (
+    TEST_BUCKET, COMMONS_CLIENT_456_FILES, COMMONS_CLIENT_459_FILES,
+    COMMONS_CLIENT_METAS, COMMONS_LOGGING_FILES, COMMONS_LOGGING_METAS,
+    ARCHETYPE_CATALOG, ARCHETYPE_CATALOG_FILES, COMMONS_CLIENT_459_MVN_NUM,
+    COMMONS_CLIENT_META_NUM, TEST_BUCKET_2
+)
+from moto import mock_s3
+import os
+
+
+@mock_s3
+class MavenDeleteMultiTgtsTest(PackageBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.mock_s3.create_bucket(Bucket=TEST_BUCKET_2)
+        self.test_bucket_2 = self.mock_s3.Bucket(TEST_BUCKET_2)
+
+    def tearDown(self):
+        buckets = [TEST_BUCKET_2]
+        self.cleanBuckets(buckets)
+        super().tearDown()
+
+    def test_maven_deletion(self):
+        self.__test_prefix_deletion("")
+
+    def test_short_prefix_deletion(self):
+        self.__test_prefix_deletion(SHORT_TEST_PREFIX)
+
+    def test_long_prefix_deletion(self):
+        self.__test_prefix_deletion(LONG_TEST_PREFIX)
+
+    def test_root_prefix_deletion(self):
+        self.__test_prefix_deletion("/")
+
+    def test_ignore_del(self):
+        self.__prepare_content()
+        product_456 = "commons-client-4.5.6"
+        product_459 = "commons-client-4.5.9"
+        product_mix = [product_456, product_459]
+
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+
+        handle_maven_del(
+            test_zip, product_456,
+            ignore_patterns=[".*.sha1"],
+            targets=[(None, TEST_BUCKET, None)],
+            dir_=self.tempdir,
+            do_index=False
+        )
+
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        objs = list(test_bucket.objects.all())
+        actual_files = [obj.key for obj in objs]
+
+        httpclient_ignored_files = [
+            "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom.sha1",
+            "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar.sha1"
+        ]
+        not_ignored = [e for e in COMMONS_CLIENT_456_FILES if e not in httpclient_ignored_files]
+        not_ignored.extend(COMMONS_CLIENT_459_FILES)
+        not_ignored.extend(
+            [e for e in COMMONS_LOGGING_FILES if e not in httpclient_ignored_files])
+        self.assertEqual(
+            len(not_ignored) * 2 + COMMONS_CLIENT_META_NUM,
+            len(actual_files)
+        )
+
+        for f in httpclient_ignored_files:
+            self.assertIn(f, actual_files)
+            self.check_product(f, [product_456])
+
+        commons_logging_sha1_files = [
+            "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar.sha1",
+            "commons-logging/commons-logging/1.2/commons-logging-1.2.jar.sha1",
+            "commons-logging/commons-logging/1.2/commons-logging-1.2.pom.sha1",
+        ]
+        for f in commons_logging_sha1_files:
+            self.assertIn(f, actual_files)
+            self.check_product(f, product_mix)
+
+        non_sha1_files = [
+            "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom",
+            "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar",
+        ]
+        for f in non_sha1_files:
+            self.assertNotIn(f, actual_files)
+
+    def __test_prefix_deletion(self, prefix: str):
+        self.__prepare_content(prefix)
+
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product_456 = "commons-client-4.5.6"
+        handle_maven_del(
+            test_zip, product_456,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            # need to double mvn num because of .prodinfo files
+            self.assertEqual(
+                COMMONS_CLIENT_459_MVN_NUM * 2 + COMMONS_CLIENT_META_NUM,
+                len(actual_files),
+                msg=f'{bucket_name}'
+            )
+
+            prefix_ = remove_prefix(target[2], "/")
+            PREFIXED_COMMONS_CLIENT_456_FILES = [
+                os.path.join(prefix_, f) for f in COMMONS_CLIENT_456_FILES]
+            for f in PREFIXED_COMMONS_CLIENT_456_FILES:
+                self.assertNotIn(f, actual_files, msg=f'{bucket_name}')
+
+            PREFIXED_COMMONS_CLIENT_METAS = [
+                os.path.join(prefix_, f) for f in COMMONS_CLIENT_METAS]
+            PREFIXED_COMMONS_LOGGING_FILES = [
+                os.path.join(prefix_, f) for f in COMMONS_LOGGING_FILES]
+            PREFIXED_COMMONS_LOGGING_METAS = [
+                os.path.join(prefix_, f) for f in COMMONS_LOGGING_METAS]
+            PREFIXED_ARCHE_CATALOG_FILES = [
+                os.path.join(prefix_, f) for f in ARCHETYPE_CATALOG_FILES]
+            file_set = [
+                *PREFIXED_COMMONS_CLIENT_METAS, *PREFIXED_ARCHE_CATALOG_FILES,
+                *PREFIXED_COMMONS_LOGGING_FILES, *PREFIXED_COMMONS_LOGGING_METAS
+            ]
+            for f in file_set:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+
+            for obj in objs:
+                if not obj.key.endswith(PROD_INFO_SUFFIX):
+                    self.assertIn(
+                        CHECKSUM_META_KEY, obj.Object().metadata, msg=f'{bucket_name}'
+                    )
+                    self.assertNotEqual(
+                        "", obj.Object().metadata[CHECKSUM_META_KEY].strip(), msg=f'{bucket_name}'
+                    )
+
+            product_459 = "commons-client-4.5.9"
+            meta_obj_client = bucket.Object(PREFIXED_COMMONS_CLIENT_METAS[0])
+            meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<groupId>org.apache.httpcomponents</groupId>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<artifactId>httpclient</artifactId>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<version>4.5.6</version>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<latest>4.5.6</latest>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<release>4.5.6</release>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<latest>4.5.9</latest>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<release>4.5.9</release>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<version>4.5.9</version>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+
+            PREFIXED_ARCHE_CATALOG = os.path.join(prefix_, ARCHETYPE_CATALOG)
+            meta_obj_cat = bucket.Object(PREFIXED_ARCHE_CATALOG)
+            meta_content_cat = str(meta_obj_cat.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<groupId>org.apache.httpcomponents</groupId>", meta_content_cat,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<artifactId>httpclient</artifactId>", meta_content_cat,
+                msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<version>4.5.6</version>", meta_content_cat,
+                msg=f'{bucket_name}'
+            )
+
+            meta_obj_logging = bucket.Object(PREFIXED_COMMONS_LOGGING_METAS[0])
+            self.assertNotIn(
+                PRODUCT_META_KEY, meta_obj_logging.metadata,
+                msg=f'{bucket_name}'
+            )
+            meta_content_logging = str(meta_obj_logging.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<groupId>commons-logging</groupId>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<artifactId>commons-logging</artifactId>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<version>1.2</version>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<latest>1.2</latest>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<release>1.2</release>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
+        handle_maven_del(
+            test_zip, product_459,
+            targets=targets_,
+            dir_=self.tempdir,
+            do_index=False
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            self.assertEqual(0, len(objs), msg=f'{bucket_name}')
+
+    def __prepare_content(self, prefix=None):
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product_456 = "commons-client-4.5.6"
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        handle_maven_uploading(
+            test_zip, product_456,
+            targets=targets_,
+            dir_=self.tempdir,
+            do_index=False
+        )
+
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
+        product_459 = "commons-client-4.5.9"
+        handle_maven_uploading(
+            test_zip, product_459,
+            targets=targets_,
+            dir_=self.tempdir,
+            do_index=False
+        )

--- a/tests/test_maven_index.py
+++ b/tests/test_maven_index.py
@@ -35,7 +35,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -78,14 +78,16 @@ class MavenFileIndexTest(PackageBaseTest):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
-            test_zip, product_456, bucket_name=TEST_BUCKET, dir_=self.tempdir
+            test_zip, product_456,
+            targets=[(TEST_BUCKET, None)],
+            dir_=self.tempdir
         )
 
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -137,9 +139,8 @@ class MavenFileIndexTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
-            dir_=self.tempdir,
-            prefix=prefix
+            targets=[(TEST_BUCKET, prefix)],
+            dir_=self.tempdir
         )
 
         test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
@@ -190,7 +191,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -237,7 +238,9 @@ class MavenFileIndexTest(PackageBaseTest):
         product_459 = "commons-client-4.5.9"
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
-            test_zip, product_459, bucket_name=TEST_BUCKET, dir_=self.tempdir
+            test_zip, product_459,
+            targets=[(TEST_BUCKET, None)],
+            dir_=self.tempdir
         )
 
         objs = list(test_bucket.objects.all())
@@ -259,8 +262,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -307,8 +309,7 @@ class MavenFileIndexTest(PackageBaseTest):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -320,8 +321,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -329,7 +329,6 @@ class MavenFileIndexTest(PackageBaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )

--- a/tests/test_maven_index.py
+++ b/tests/test_maven_index.py
@@ -35,7 +35,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -79,7 +79,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -87,7 +87,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -139,7 +139,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -191,7 +191,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -239,7 +239,7 @@ class MavenFileIndexTest(PackageBaseTest):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
             test_zip, product_459,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -262,7 +262,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -309,7 +309,7 @@ class MavenFileIndexTest(PackageBaseTest):
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         handle_maven_del(
             test_zip, product_459,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -321,7 +321,7 @@ class MavenFileIndexTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -329,6 +329,6 @@ class MavenFileIndexTest(PackageBaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )

--- a/tests/test_maven_index_multi_tgts.py
+++ b/tests/test_maven_index_multi_tgts.py
@@ -1,0 +1,429 @@
+"""
+Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/charon)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from charon.constants import PROD_INFO_SUFFIX
+from charon.pkgs.maven import handle_maven_uploading, handle_maven_del
+from charon.storage import CHECKSUM_META_KEY
+from charon.utils.strings import remove_prefix
+from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, PackageBaseTest
+from tests.commons import (
+    TEST_BUCKET, COMMONS_CLIENT_456_INDEXES, COMMONS_CLIENT_459_INDEXES,
+    COMMONS_LOGGING_INDEXES, COMMONS_CLIENT_INDEX, COMMONS_CLIENT_456_INDEX,
+    COMMONS_LOGGING_INDEX, COMMONS_ROOT_INDEX, TEST_BUCKET_2
+)
+from moto import mock_s3
+import os
+
+
+@mock_s3
+class MavenFileIndexMultiTgtsTest(PackageBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.mock_s3.create_bucket(Bucket=TEST_BUCKET_2)
+        self.test_bucket_2 = self.mock_s3.Bucket(TEST_BUCKET_2)
+
+    def tearDown(self):
+        buckets = [TEST_BUCKET_2]
+        self.cleanBuckets(buckets)
+        super().tearDown()
+
+    def test_uploading_index(self):
+        targets_ = [(None, TEST_BUCKET, None), (None, TEST_BUCKET_2, None)]
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product = "commons-client-4.5.6"
+        handle_maven_uploading(
+            test_zip, product,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+
+            self.assertEqual(41, len(actual_files), msg=f'{bucket_name}')
+
+            for f in COMMONS_LOGGING_INDEXES:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+
+            for f in COMMONS_CLIENT_456_INDEXES:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+
+            self.check_content(objs, [product])
+
+            indedx_obj = bucket.Object(COMMONS_CLIENT_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"maven-metadata.xml\" "
+                "title=\"maven-metadata.xml\">maven-metadata.xml</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(COMMONS_ROOT_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"org/\" title=\"org/\">org/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"commons-logging/\" "
+                "title=\"commons-logging/\">commons-logging/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+    def test_overlap_upload_index(self):
+        targets_ = [(None, TEST_BUCKET, None), (None, TEST_BUCKET_2, None)]
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product_456 = "commons-client-4.5.6"
+        handle_maven_uploading(
+            test_zip, product_456,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
+        product_459 = "commons-client-4.5.9"
+        handle_maven_uploading(
+            test_zip, product_459,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            self.assertEqual(50, len(objs), msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(COMMONS_CLIENT_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"4.5.9/\" title=\"4.5.9/\">4.5.9/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"maven-metadata.xml\" "
+                "title=\"maven-metadata.xml\">maven-metadata.xml</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(COMMONS_LOGGING_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"1.2/\" title=\"1.2/\">1.2/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"maven-metadata.xml\" "
+                "title=\"maven-metadata.xml\">maven-metadata.xml</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(COMMONS_ROOT_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"org/\" title=\"org/\">org/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"commons-logging/\" "
+                "title=\"commons-logging/\">commons-logging/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+    def test_upload_index_with_short_prefix(self):
+        self.__test_upload_index_with_prefix(SHORT_TEST_PREFIX)
+
+    def test_upload_index_with_long_prefix(self):
+        self.__test_upload_index_with_prefix(LONG_TEST_PREFIX)
+
+    def test_upload_index_with_root_prefix(self):
+        self.__test_upload_index_with_prefix("/")
+
+    def __test_upload_index_with_prefix(self, prefix: str):
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product = "commons-client-4.5.6"
+        handle_maven_uploading(
+            test_zip, product,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            self.assertEqual(41, len(actual_files), msg=f'{bucket_name}')
+
+            prefix_ = remove_prefix(prefix, "/")
+            PREFIXED_LOGGING_INDEXES = [
+                os.path.join(prefix_, i) for i in COMMONS_LOGGING_INDEXES
+            ]
+            for f in PREFIXED_LOGGING_INDEXES:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+
+            PREFIXED_456_INDEXES = [
+                os.path.join(prefix_, i) for i in COMMONS_CLIENT_456_INDEXES
+            ]
+            for f in PREFIXED_456_INDEXES:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+
+            self.check_content(objs, [product], msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(os.path.join(prefix_, COMMONS_CLIENT_INDEX))
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"maven-metadata.xml\" "
+                "title=\"maven-metadata.xml\">maven-metadata.xml</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(os.path.join(prefix_, COMMONS_ROOT_INDEX))
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"org/\" title=\"org/\">org/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"commons-logging/\" "
+                "title=\"commons-logging/\">commons-logging/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+    def test_deletion_index(self):
+        self.__prepare_content()
+
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product_456 = "commons-client-4.5.6"
+        handle_maven_del(
+            test_zip, product_456,
+            targets=[(None, TEST_BUCKET, None)],
+            dir_=self.tempdir
+        )
+
+        test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
+        objs = list(test_bucket.objects.all())
+        actual_files = [obj.key for obj in objs]
+        self.assertEqual(41, len(actual_files))
+
+        for assert_file in COMMONS_CLIENT_459_INDEXES:
+            self.assertIn(assert_file, actual_files)
+
+        for assert_file in COMMONS_LOGGING_INDEXES:
+            self.assertIn(assert_file, actual_files)
+
+        self.assertNotIn(COMMONS_CLIENT_456_INDEX, actual_files)
+
+        for obj in objs:
+            if not obj.key.endswith(PROD_INFO_SUFFIX):
+                file_obj = obj.Object()
+                self.assertIn(CHECKSUM_META_KEY, file_obj.metadata)
+                self.assertNotEqual("", file_obj.metadata[CHECKSUM_META_KEY].strip())
+
+        indedx_obj = test_bucket.Object(COMMONS_CLIENT_INDEX)
+        index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+        self.assertIn("<a href=\"4.5.9/\" title=\"4.5.9/\">4.5.9/</a>", index_content)
+        self.assertIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertIn(
+            "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>",
+            index_content)
+        self.assertNotIn("<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>", index_content)
+        self.assertNotIn(PROD_INFO_SUFFIX, index_content)
+
+        indedx_obj = test_bucket.Object(COMMONS_ROOT_INDEX)
+        index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+        self.assertIn("<a href=\"org/\" title=\"org/\">org/</a>", index_content)
+        self.assertIn(
+            "<a href=\"commons-logging/\" "
+            "title=\"commons-logging/\">commons-logging/</a>",
+            index_content
+        )
+        self.assertNotIn("<a href=\"../\" title=\"../\">../</a>", index_content)
+        self.assertNotIn(PROD_INFO_SUFFIX, index_content)
+
+        product_459 = "commons-client-4.5.9"
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
+        handle_maven_del(
+            test_zip, product_459,
+            targets=[(None, TEST_BUCKET, None)],
+            dir_=self.tempdir
+        )
+
+        objs = list(test_bucket.objects.all())
+        self.assertEqual(0, len(objs))
+
+    def test_deletion_index_with_short_prefix(self):
+        self.__test_deletion_index_with_prefix(SHORT_TEST_PREFIX)
+
+    def test_deletion_index_with_long_prefix(self):
+        self.__test_deletion_index_with_prefix(LONG_TEST_PREFIX)
+
+    def test_deletion_index_with_root_prefix(self):
+        self.__test_deletion_index_with_prefix("/")
+
+    def __test_deletion_index_with_prefix(self, prefix: str):
+        self.__prepare_content(prefix)
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product_456 = "commons-client-4.5.6"
+        handle_maven_del(
+            test_zip, product_456,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        product_459 = "commons-client-4.5.9"
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            self.assertEqual(41, len(actual_files), msg=f'{bucket_name}')
+
+            prefix_ = remove_prefix(prefix, "/")
+            PREFIXED_459_INDEXES = [os.path.join(prefix_, i) for i in COMMONS_CLIENT_459_INDEXES]
+            for assert_file in PREFIXED_459_INDEXES:
+                self.assertIn(assert_file, actual_files, msg=f'{bucket_name}')
+
+            PREFIXED_LOGGING_INDEXES = [os.path.join(prefix_, i) for i in COMMONS_LOGGING_INDEXES]
+            for assert_file in PREFIXED_LOGGING_INDEXES:
+                self.assertIn(assert_file, actual_files, msg=f'{bucket_name}')
+
+            self.assertNotIn(
+                os.path.join(prefix_, COMMONS_CLIENT_456_INDEX),
+                actual_files, msg=f'{bucket_name}'
+            )
+
+            self.check_content(objs, [product_459], msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(os.path.join(prefix_, COMMONS_CLIENT_INDEX))
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"4.5.9/\" title=\"4.5.9/\">4.5.9/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"maven-metadata.xml\" "
+                "title=\"maven-metadata.xml\">maven-metadata.xml</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<a href=\"4.5.6/\" title=\"4.5.6/\">4.5.6/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(os.path.join(prefix_, COMMONS_ROOT_INDEX))
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"org/\" title=\"org/\">org/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"commons-logging/\" "
+                "title=\"commons-logging/\">commons-logging/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<a href=\"../\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
+        handle_maven_del(
+            test_zip, product_459,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            self.assertEqual(0, len(objs), msg=f'{bucket_name}')
+
+    def __prepare_content(self, prefix=None):
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product_456 = "commons-client-4.5.6"
+        handle_maven_uploading(
+            test_zip, product_456,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
+        product_459 = "commons-client-4.5.9"
+        handle_maven_uploading(
+            test_zip, product_459,
+            targets=targets_,
+            dir_=self.tempdir
+        )

--- a/tests/test_maven_upload.py
+++ b/tests/test_maven_upload.py
@@ -46,7 +46,7 @@ class MavenUploadTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir, do_index=False
         )
 
@@ -54,7 +54,7 @@ class MavenUploadTest(PackageBaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir, do_index=False
         )
 
@@ -113,7 +113,7 @@ class MavenUploadTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456, [".*.sha1"],
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir, do_index=False
         )
 
@@ -142,7 +142,7 @@ class MavenUploadTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            targets=[(TEST_BUCKET, prefix)],
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir,
             do_index=False
         )

--- a/tests/test_maven_upload.py
+++ b/tests/test_maven_upload.py
@@ -46,14 +46,16 @@ class MavenUploadTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            targets=[(TEST_BUCKET, None)],
+            dir_=self.tempdir, do_index=False
         )
 
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            targets=[(TEST_BUCKET, None)],
+            dir_=self.tempdir, do_index=False
         )
 
         objs = list(self.test_bucket.objects.all())
@@ -111,7 +113,8 @@ class MavenUploadTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456, [".*.sha1"],
-            bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            targets=[(TEST_BUCKET, None)],
+            dir_=self.tempdir, do_index=False
         )
 
         objs = list(self.test_bucket.objects.all())
@@ -139,8 +142,7 @@ class MavenUploadTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            targets=[(TEST_BUCKET, prefix)],
             dir_=self.tempdir,
             do_index=False
         )

--- a/tests/test_maven_upload_multi_tgts.py
+++ b/tests/test_maven_upload_multi_tgts.py
@@ -1,0 +1,317 @@
+"""
+Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/charon)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from typing import List, Tuple
+from charon.pkgs.maven import handle_maven_uploading
+from charon.utils.strings import remove_prefix
+from tests.base import SHORT_TEST_PREFIX, LONG_TEST_PREFIX, PackageBaseTest
+from tests.commons import (
+    TEST_BUCKET, COMMONS_CLIENT_456_FILES, COMMONS_CLIENT_459_FILES,
+    COMMONS_CLIENT_METAS, COMMONS_LOGGING_FILES, COMMONS_LOGGING_METAS,
+    NON_MVN_FILES, ARCHETYPE_CATALOG, ARCHETYPE_CATALOG_FILES,
+    COMMONS_CLIENT_456_MVN_NUM, COMMONS_CLIENT_MVN_NUM,
+    COMMONS_CLIENT_META_NUM, TEST_BUCKET_2
+)
+from moto import mock_s3
+import os
+
+
+@mock_s3
+class MavenUploadMultiTgtsTest(PackageBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.mock_s3.create_bucket(Bucket=TEST_BUCKET_2)
+        self.test_bucket_2 = self.mock_s3.Bucket(TEST_BUCKET_2)
+
+    def tearDown(self):
+        buckets = [TEST_BUCKET_2]
+        self.cleanBuckets(buckets)
+        super().tearDown()
+
+    def test_fresh_upload(self):
+        self.__test_prefix_upload(
+            [(None, TEST_BUCKET, ""), (None, TEST_BUCKET_2, "")]
+        )
+
+    def test_short_prefix_upload(self):
+        self.__test_prefix_upload(
+            [(None, TEST_BUCKET, SHORT_TEST_PREFIX), (None, TEST_BUCKET_2, SHORT_TEST_PREFIX)]
+        )
+
+    def test_long_prefix_upload(self):
+        self.__test_prefix_upload(
+            [(None, TEST_BUCKET, LONG_TEST_PREFIX), (None, TEST_BUCKET_2, LONG_TEST_PREFIX)]
+        )
+
+    def test_root_prefix_upload(self):
+        self.__test_prefix_upload([(None, TEST_BUCKET, "/"), (None, TEST_BUCKET_2, "/")])
+
+    def test_overlap_upload(self):
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product_456 = "commons-client-4.5.6"
+        targets_ = [
+            (None, TEST_BUCKET, None), (None, TEST_BUCKET_2, None)
+        ]
+        handle_maven_uploading(
+            test_zip, product_456,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
+        product_459 = "commons-client-4.5.9"
+        handle_maven_uploading(
+            test_zip, product_459,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            # need to double mvn num because of .prodinfo files
+            expected = COMMONS_CLIENT_MVN_NUM * 2 + COMMONS_CLIENT_META_NUM
+            self.assertEqual(
+                expected,
+                len(actual_files),
+                msg=f'{bucket_name}'
+            )
+
+            filesets = [
+                COMMONS_CLIENT_METAS, COMMONS_CLIENT_456_FILES,
+                COMMONS_CLIENT_459_FILES,
+                ARCHETYPE_CATALOG_FILES
+            ]
+            for fileset in filesets:
+                for f in fileset:
+                    self.assertIn(f, actual_files, msg=f'{bucket_name}')
+
+            product_mix = [product_456, product_459]
+            for f in COMMONS_LOGGING_FILES:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+                self.check_product(f, product_mix, msg=f'{bucket_name}')
+            for f in COMMONS_LOGGING_METAS:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+
+            meta_obj_client = self.test_bucket.Object(COMMONS_CLIENT_METAS[0])
+            meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<groupId>org.apache.httpcomponents</groupId>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<artifactId>httpclient</artifactId>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<latest>4.5.9</latest>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<release>4.5.9</release>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<version>4.5.6</version>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<version>4.5.9</version>", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+
+            meta_obj_logging = self.test_bucket.Object(COMMONS_LOGGING_METAS[0])
+            meta_content_logging = str(meta_obj_logging.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<groupId>commons-logging</groupId>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<artifactId>commons-logging</artifactId>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<version>1.2</version>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<latest>1.2</latest>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<release>1.2</release>", meta_content_logging,
+                msg=f'{bucket_name}'
+            )
+
+            catalog = self.test_bucket.Object(ARCHETYPE_CATALOG)
+            cat_content = str(catalog.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<version>4.5.6</version>", cat_content,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<version>4.5.9</version>", cat_content,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<artifactId>httpclient</artifactId>", cat_content,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<groupId>org.apache.httpcomponents</groupId>", cat_content,
+                msg=f'{bucket_name}'
+            )
+
+    def test_ignore_upload(self):
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product_456 = "commons-client-4.5.6"
+        targets_ = [
+            (None, TEST_BUCKET, None), (None, TEST_BUCKET_2, None)
+        ]
+        handle_maven_uploading(
+            test_zip, product_456, [".*.sha1"],
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+
+        ignored_files = [
+                "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.pom.sha1",
+                "org/apache/httpcomponents/httpclient/4.5.6/httpclient-4.5.6.jar.sha1",
+                "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar.sha1",
+                "commons-logging/commons-logging/1.2/commons-logging-1.2.jar.sha1",
+                "commons-logging/commons-logging/1.2/commons-logging-1.2.pom.sha1"
+            ]
+        not_ignored = [e for e in COMMONS_CLIENT_456_FILES if e not in ignored_files]
+        not_ignored.extend(
+                [e for e in COMMONS_LOGGING_FILES if e not in ignored_files])
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+
+            # need to double mvn num because of .prodinfo files
+            self.assertEqual(
+                len(not_ignored) * 2 + COMMONS_CLIENT_META_NUM, len(actual_files),
+                msg=f'{bucket_name}'
+            )
+            for f in not_ignored:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+            for f in ignored_files:
+                self.assertNotIn(f, actual_files, msg=f'{bucket_name}')
+
+    def __test_prefix_upload(self, targets: List[Tuple[str, str, str]]):
+        test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.6.zip")
+        product = "commons-client-4.5.6"
+        handle_maven_uploading(
+            test_zip, product,
+            targets=targets,
+            dir_=self.tempdir,
+            do_index=False
+        )
+
+        for target in targets:
+            bucket = self.mock_s3.Bucket(target[1])
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            # need to double mvn num because of .prodinfo files
+            expected = COMMONS_CLIENT_456_MVN_NUM * 2 + COMMONS_CLIENT_META_NUM
+            self.assertEqual(
+                expected, len(actual_files),
+                msg=f"{bucket.name}"
+            )
+
+            prefix_ = remove_prefix(target[2], "/")
+            PREFIXED_COMMONS_CLIENT_456_FILES = [
+                os.path.join(prefix_, f) for f in COMMONS_CLIENT_456_FILES]
+            PREFIXED_COMMONS_CLIENT_METAS = [
+                os.path.join(prefix_, f) for f in COMMONS_CLIENT_METAS]
+            PREFIXED_COMMONS_LOGGING_FILES = [
+                os.path.join(prefix_, f) for f in COMMONS_LOGGING_FILES]
+            PREFIXED_COMMONS_LOGGING_METAS = [
+                os.path.join(prefix_, f) for f in COMMONS_LOGGING_METAS]
+            PREFIXED_ARCHETYPE_CATALOG_FILES = [
+                os.path.join(prefix_, f) for f in ARCHETYPE_CATALOG_FILES]
+            file_set = [
+                *PREFIXED_COMMONS_CLIENT_456_FILES, *PREFIXED_COMMONS_CLIENT_METAS,
+                *PREFIXED_COMMONS_LOGGING_FILES, *PREFIXED_COMMONS_LOGGING_METAS,
+                *PREFIXED_ARCHETYPE_CATALOG_FILES
+            ]
+            for f in file_set:
+                self.assertIn(f, actual_files, msg=f"{bucket.name}")
+
+            PREFIXED_NON_MVN_FILES = [
+                os.path.join(prefix_, f) for f in NON_MVN_FILES]
+            for f in PREFIXED_NON_MVN_FILES:
+                self.assertNotIn(f, actual_files, msg=f"{bucket.name}")
+
+            self.check_content(objs, [product], msg=f"{bucket.name}")
+
+            meta_obj_client = self.test_bucket.Object(PREFIXED_COMMONS_CLIENT_METAS[0])
+            meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<groupId>org.apache.httpcomponents</groupId>", meta_content_client,
+                msg=f"{bucket.name}"
+            )
+            self.assertIn("<artifactId>httpclient</artifactId>", meta_content_client,
+                          msg=f"{bucket.name}")
+            self.assertIn("<version>4.5.6</version>", meta_content_client,
+                          msg=f"{bucket.name}")
+            self.assertIn("<latest>4.5.6</latest>", meta_content_client,
+                          msg=f"{bucket.name}")
+            self.assertIn("<release>4.5.6</release>", meta_content_client,
+                          msg=f"{bucket.name}")
+            self.assertNotIn("<version>4.5.9</version>", meta_content_client,
+                             msg=f"{bucket.name}")
+
+            meta_obj_logging = self.test_bucket.Object(PREFIXED_COMMONS_LOGGING_METAS[0])
+            meta_content_logging = str(meta_obj_logging.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<groupId>commons-logging</groupId>", meta_content_logging,
+                msg=f"{bucket.name}"
+            )
+            self.assertIn(
+                "<artifactId>commons-logging</artifactId>", meta_content_logging,
+                msg=f"{bucket.name}"
+            )
+            self.assertIn(
+                "<version>1.2</version>", meta_content_logging,
+                msg=f"{bucket.name}"
+            )
+            self.assertIn(
+                "<latest>1.2</latest>", meta_content_logging,
+                msg=f"{bucket.name}"
+            )
+            self.assertIn(
+                "<release>1.2</release>", meta_content_logging,
+                msg=f"{bucket.name}"
+            )
+
+            catalog = self.test_bucket.Object(PREFIXED_ARCHETYPE_CATALOG_FILES[0])
+            cat_content = str(catalog.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<version>4.5.6</version>", cat_content,
+                msg=f"{bucket.name}"
+            )
+            self.assertIn(
+                "<artifactId>httpclient</artifactId>", cat_content,
+                msg=f"{bucket.name}"
+            )
+            self.assertIn(
+                "<groupId>org.apache.httpcomponents</groupId>", cat_content,
+                msg=f"{bucket.name}"
+            )

--- a/tests/test_npm_del.py
+++ b/tests/test_npm_del.py
@@ -43,7 +43,7 @@ class NPMDeleteTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir, do_index=False
         )
 
@@ -87,7 +87,7 @@ class NPMDeleteTest(PackageBaseTest):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         handle_npm_del(
             test_tgz, product_7_15_8,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir, do_index=False
         )
         objs = list(test_bucket.objects.all())
@@ -98,7 +98,7 @@ class NPMDeleteTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir, do_index=False
         )
 
@@ -106,6 +106,6 @@ class NPMDeleteTest(PackageBaseTest):
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
             test_tgz, product_7_15_8,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir, do_index=False
         )

--- a/tests/test_npm_del.py
+++ b/tests/test_npm_del.py
@@ -43,7 +43,7 @@ class NPMDeleteTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir, do_index=False
         )
 
@@ -87,7 +87,7 @@ class NPMDeleteTest(PackageBaseTest):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         handle_npm_del(
             test_tgz, product_7_15_8,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir, do_index=False
         )
         objs = list(test_bucket.objects.all())
@@ -98,7 +98,7 @@ class NPMDeleteTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir, do_index=False
         )
 
@@ -106,6 +106,6 @@ class NPMDeleteTest(PackageBaseTest):
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
             test_tgz, product_7_15_8,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir, do_index=False
         )

--- a/tests/test_npm_del_multi_tgts.py
+++ b/tests/test_npm_del_multi_tgts.py
@@ -1,0 +1,151 @@
+"""
+Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/charon)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+from moto import mock_s3
+from charon.constants import PROD_INFO_SUFFIX
+from charon.pkgs.npm import handle_npm_uploading, handle_npm_del
+from charon.storage import CHECKSUM_META_KEY
+from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, PackageBaseTest
+from tests.commons import TEST_BUCKET, CODE_FRAME_7_14_5_FILES, CODE_FRAME_META, TEST_BUCKET_2
+
+
+@mock_s3
+class NPMDeleteMultiTgtsTest(PackageBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.mock_s3.create_bucket(Bucket=TEST_BUCKET_2)
+        self.test_bucket_2 = self.mock_s3.Bucket(TEST_BUCKET_2)
+
+    def tearDown(self):
+        buckets = [TEST_BUCKET_2]
+        self.cleanBuckets(buckets)
+        super().tearDown()
+
+    def test_npm_deletion(self):
+        self.__test_prefix()
+
+    def test_npm_deletion_with_short_prefix(self):
+        self.__test_prefix(SHORT_TEST_PREFIX)
+
+    def test_npm_deletion_with_long_prefix(self):
+        self.__test_prefix(LONG_TEST_PREFIX)
+
+    def test_npm_deletion_with_root_prefix(self):
+        self.__test_prefix("/")
+
+    def __test_prefix(self, prefix: str = None):
+        self.__prepare_content(prefix)
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
+        product_7_14_5 = "code-frame-7.14.5"
+        handle_npm_del(
+            test_tgz, product_7_14_5,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            self.assertEqual(5, len(actual_files), msg=f'{bucket_name}')
+
+            PREFIXED_7145_FILES = CODE_FRAME_7_14_5_FILES
+            PREFIXED_FRAME_META = CODE_FRAME_META
+            if prefix and prefix != "/":
+                PREFIXED_7145_FILES = [
+                    os.path.join(prefix, f) for f in CODE_FRAME_7_14_5_FILES
+                ]
+                PREFIXED_FRAME_META = os.path.join(prefix, CODE_FRAME_META)
+            for f in PREFIXED_7145_FILES:
+                self.assertNotIn(f, actual_files, msg=f'{bucket_name}')
+            self.assertIn(PREFIXED_FRAME_META, actual_files, msg=f'{bucket_name}')
+
+            for obj in objs:
+                if not obj.key.endswith(PROD_INFO_SUFFIX):
+                    self.assertIn(
+                        CHECKSUM_META_KEY, obj.Object().metadata, msg=f'{bucket_name}'
+                    )
+                    self.assertNotEqual(
+                        "", obj.Object().metadata[CHECKSUM_META_KEY].strip(), msg=f'{bucket_name}'
+                    )
+
+            product_7_15_8 = "code-frame-7.15.8"
+            meta_obj = bucket.Object(PREFIXED_FRAME_META)
+            # self.check_product(meta_obj.key, [product_7_15_8])
+            meta_content_client = str(meta_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "\"name\": \"@babel/code-frame\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"description\": \"Generate errors that contain a code frame that point to "
+                "source locations.\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"repository\": {\"type\": \"git\", \"url\": "
+                "\"https://github.com/babel/babel.git\"",
+                meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"version\": \"7.15.8\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "\"version\": \"7.14.5\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"versions\": {\"7.15.8\":", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "\"7.14.5\": {\"name\":", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"license\": \"MIT\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"dist_tags\": {\"latest\": \"7.15.8\"}",
+                meta_content_client, msg=f'{bucket_name}'
+            )
+
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
+        handle_npm_del(
+            test_tgz, product_7_15_8,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            self.assertEqual(0, len(objs))
+
+    def __prepare_content(self, prefix: str = None):
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
+        product_7_14_5 = "code-frame-7.14.5"
+        handle_npm_uploading(
+            test_tgz, product_7_14_5,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
+        product_7_15_8 = "code-frame-7.15.8"
+        handle_npm_uploading(
+            test_tgz, product_7_15_8,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )

--- a/tests/test_npm_index.py
+++ b/tests/test_npm_index.py
@@ -46,7 +46,7 @@ class NpmFileIndexTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir,
         )
 
@@ -126,8 +126,7 @@ class NpmFileIndexTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET,
-            prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir
         )
 
@@ -158,7 +157,7 @@ class NpmFileIndexTest(PackageBaseTest):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         handle_npm_del(
             test_tgz, product_7_15_8,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir
         )
 
@@ -170,7 +169,7 @@ class NpmFileIndexTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir
         )
 
@@ -178,6 +177,6 @@ class NpmFileIndexTest(PackageBaseTest):
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
             test_tgz, product_7_15_8,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir
         )

--- a/tests/test_npm_index.py
+++ b/tests/test_npm_index.py
@@ -46,7 +46,7 @@ class NpmFileIndexTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir,
         )
 
@@ -126,7 +126,7 @@ class NpmFileIndexTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -157,7 +157,7 @@ class NpmFileIndexTest(PackageBaseTest):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         handle_npm_del(
             test_tgz, product_7_15_8,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -169,7 +169,7 @@ class NpmFileIndexTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )
 
@@ -177,6 +177,6 @@ class NpmFileIndexTest(PackageBaseTest):
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
             test_tgz, product_7_15_8,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir
         )

--- a/tests/test_npm_index_multi_tgts.py
+++ b/tests/test_npm_index_multi_tgts.py
@@ -1,0 +1,237 @@
+"""
+Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/charon)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from charon.constants import PROD_INFO_SUFFIX
+from charon.pkgs.npm import handle_npm_uploading, handle_npm_del
+from charon.storage import CHECKSUM_META_KEY
+from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, PackageBaseTest
+from tests.commons import (
+    TEST_BUCKET, CODE_FRAME_7_14_5_INDEXES,
+    CODE_FRAME_7_15_8_INDEXES, COMMONS_ROOT_INDEX,
+    TEST_BUCKET_2
+)
+from moto import mock_s3
+import os
+
+NAMESPACE_BABEL_INDEX = "@babel/index.html"
+
+
+@mock_s3
+class NpmFileIndexMultiTgtsTest(PackageBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.mock_s3.create_bucket(Bucket=TEST_BUCKET_2)
+        self.test_bucket_2 = self.mock_s3.Bucket(TEST_BUCKET_2)
+
+    def tearDown(self):
+        buckets = [TEST_BUCKET_2]
+        self.cleanBuckets(buckets)
+        super().tearDown()
+
+    def test_uploading_index(self):
+        self.__test_upload_prefix()
+
+    def test_uploding_index_with_short_prefix(self):
+        self.__test_upload_prefix(SHORT_TEST_PREFIX)
+
+    def test_uploding_index_with_long_prefix(self):
+        self.__test_upload_prefix(LONG_TEST_PREFIX)
+
+    def test_uploding_index_with_root_prefix(self):
+        self.__test_upload_prefix("/")
+
+    def __test_upload_prefix(self, prefix: str = None):
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
+        product_7_14_5 = "code-frame-7.14.5"
+        handle_npm_uploading(
+            test_tgz, product_7_14_5,
+            targets=targets_,
+            dir_=self.tempdir,
+        )
+
+        PREFIXED_7158_INDEXES = CODE_FRAME_7_15_8_INDEXES
+        PREFIXED_NAMESPACE_BABEL_INDEX = NAMESPACE_BABEL_INDEX
+        PREFIXED_ROOT_INDEX = COMMONS_ROOT_INDEX
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            self.assertEqual(7, len(actual_files), msg=f'{bucket_name}')
+
+            if prefix and prefix != "/":
+                PREFIXED_7158_INDEXES = [
+                    os.path.join(prefix, f) for f in CODE_FRAME_7_15_8_INDEXES
+                ]
+                PREFIXED_NAMESPACE_BABEL_INDEX = os.path.join(prefix, NAMESPACE_BABEL_INDEX)
+                PREFIXED_ROOT_INDEX = os.path.join(prefix, COMMONS_ROOT_INDEX)
+
+            for assert_file in PREFIXED_7158_INDEXES:
+                self.assertNotIn(assert_file, actual_files, msg=f'{bucket_name}')
+
+            for obj in objs:
+                if not obj.key.endswith(PROD_INFO_SUFFIX):
+                    self.assertIn(
+                        CHECKSUM_META_KEY, obj.Object().metadata, msg=f'{bucket_name}'
+                    )
+                    self.assertNotEqual(
+                        "", obj.Object().metadata[CHECKSUM_META_KEY].strip(), msg=f'{bucket_name}'
+                    )
+
+            indedx_obj = bucket.Object(PREFIXED_NAMESPACE_BABEL_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"code-frame/\" title=\"code-frame/\">code-frame/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"../index.html\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(PREFIXED_ROOT_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"@babel/index.html\" title=\"@babel/\">@babel/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                "<a href=\"../index.html\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+    def test_overlap_upload_index(self):
+        self.__prepare_content()
+        targets_ = [(None, TEST_BUCKET, None), (None, TEST_BUCKET_2, None)]
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            self.assertEqual(11, len(objs), msg=f'{bucket_name}')
+
+            self.assertIn(
+                NAMESPACE_BABEL_INDEX, actual_files, msg=f'{bucket_name}'
+            )
+            for assert_file in CODE_FRAME_7_14_5_INDEXES:
+                self.assertNotIn(assert_file, actual_files, msg=f'{bucket_name}')
+            for assert_file in CODE_FRAME_7_15_8_INDEXES:
+                self.assertNotIn(assert_file, actual_files, msg=f'{bucket_name}')
+
+            indedx_obj = bucket.Object(NAMESPACE_BABEL_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"code-frame/\" title=\"code-frame/\">code-frame/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"../index.html\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(
+                PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}'
+            )
+
+    def test_deletion_index(self):
+        self.__test_deletion_prefix()
+
+    def test_deletion_index_with_short_prefix(self):
+        self.__test_deletion_prefix(SHORT_TEST_PREFIX)
+
+    def test_deletion_index_with_long_prefix(self):
+        self.__test_deletion_prefix(LONG_TEST_PREFIX)
+
+    def test_deletion_index_with_root_prefix(self):
+        self.__test_deletion_prefix("/")
+
+    def __test_deletion_prefix(self, prefix: str = None):
+        self.__prepare_content(prefix)
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
+        product_7_14_5 = "code-frame-7.14.5"
+        handle_npm_del(
+            test_tgz, product_7_14_5,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        PREFIXED_NAMESPACE_BABEL_INDEX = NAMESPACE_BABEL_INDEX
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            self.assertEqual(7, len(objs), msg=f'{bucket_name}')
+
+            if prefix and prefix != "/":
+                PREFIXED_NAMESPACE_BABEL_INDEX = os.path.join(prefix, NAMESPACE_BABEL_INDEX)
+
+            self.assertIn(PREFIXED_NAMESPACE_BABEL_INDEX, actual_files, msg=f'{bucket_name}')
+
+            for obj in objs:
+                if not obj.key.endswith(PROD_INFO_SUFFIX):
+                    self.assertIn(
+                        CHECKSUM_META_KEY, obj.Object().metadata, msg=f'{bucket_name}'
+                    )
+                    self.assertNotEqual(
+                        "", obj.Object().metadata[CHECKSUM_META_KEY].strip(), msg=f'{bucket_name}'
+                    )
+
+            indedx_obj = bucket.Object(PREFIXED_NAMESPACE_BABEL_INDEX)
+            index_content = str(indedx_obj.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "<a href=\"code-frame/\" title=\"code-frame/\">code-frame/</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "<a href=\"../index.html\" title=\"../\">../</a>",
+                index_content, msg=f'{bucket_name}'
+            )
+            self.assertNotIn(PROD_INFO_SUFFIX, index_content, msg=f'{bucket_name}')
+
+        product_7_15_8 = "code-frame-7.15.8"
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
+        handle_npm_del(
+            test_tgz, product_7_15_8,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            self.assertEqual(0, len(objs), msg=f'{bucket_name}')
+
+    def __prepare_content(self, prefix: str = None):
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
+        product_7_14_5 = "code-frame-7.14.5"
+        handle_npm_uploading(
+            test_tgz, product_7_14_5,
+            targets=targets_,
+            dir_=self.tempdir
+        )
+
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
+        product_7_15_8 = "code-frame-7.15.8"
+        handle_npm_uploading(
+            test_tgz, product_7_15_8,
+            targets=targets_,
+            dir_=self.tempdir
+        )

--- a/tests/test_npm_meta.py
+++ b/tests/test_npm_meta.py
@@ -61,11 +61,11 @@ class NPMMetadataOnS3Test(BaseTest):
         bucket.put_object(
             Key='@redhat/kogito-tooling-workspace/package.json',
             Body=str(original_version_0_5_8_package_json)
-            )
+        )
         tarball_test_path = os.path.join(
             os.getcwd(),
             'tests/input/kogito-tooling-workspace-0.9.0-3.tgz'
-            )
+        )
         handle_npm_uploading(
             tarball_test_path, "kogito-tooling-workspace-0.9.0-3",
             targets=[(None, MY_BUCKET, None)],
@@ -74,7 +74,7 @@ class NPMMetadataOnS3Test(BaseTest):
         (files, _) = self.s3_client.get_files(
             bucket_name=MY_BUCKET,
             prefix='@redhat/kogito-tooling-workspace/package.json'
-            )
+        )
         self.assertEqual(1, len(files))
         self.assertIn('@redhat/kogito-tooling-workspace/package.json', files)
 

--- a/tests/test_npm_meta.py
+++ b/tests/test_npm_meta.py
@@ -67,7 +67,8 @@ class NPMMetadataOnS3Test(BaseTest):
             'tests/input/kogito-tooling-workspace-0.9.0-3.tgz'
             )
         handle_npm_uploading(
-            tarball_test_path, "kogito-tooling-workspace-0.9.0-3", bucket_name=MY_BUCKET,
+            tarball_test_path, "kogito-tooling-workspace-0.9.0-3",
+            target=(MY_BUCKET, None),
             dir_=self.tempdir
             )
         (files, _) = self.s3_client.get_files(
@@ -119,7 +120,8 @@ class NPMMetadataOnS3Test(BaseTest):
             'tests/input/kogito-tooling-workspace-0.9.0-3.tgz'
         )
         handle_npm_uploading(
-            tarball_test_path, "kogito-tooling-workspace-0.9.0-3", bucket_name=MY_BUCKET,
+            tarball_test_path, "kogito-tooling-workspace-0.9.0-3",
+            target=(MY_BUCKET, None),
             dir_=self.tempdir
         )
         (files, _) = self.s3_client.get_files(

--- a/tests/test_npm_meta.py
+++ b/tests/test_npm_meta.py
@@ -68,9 +68,9 @@ class NPMMetadataOnS3Test(BaseTest):
             )
         handle_npm_uploading(
             tarball_test_path, "kogito-tooling-workspace-0.9.0-3",
-            target=(MY_BUCKET, None),
+            targets=[(None, MY_BUCKET, None)],
             dir_=self.tempdir
-            )
+        )
         (files, _) = self.s3_client.get_files(
             bucket_name=MY_BUCKET,
             prefix='@redhat/kogito-tooling-workspace/package.json'
@@ -121,7 +121,7 @@ class NPMMetadataOnS3Test(BaseTest):
         )
         handle_npm_uploading(
             tarball_test_path, "kogito-tooling-workspace-0.9.0-3",
-            target=(MY_BUCKET, None),
+            targets=[(None, MY_BUCKET, None)],
             dir_=self.tempdir
         )
         (files, _) = self.s3_client.get_files(

--- a/tests/test_npm_upload.py
+++ b/tests/test_npm_upload.py
@@ -48,14 +48,14 @@ class NPMUploadTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, None),
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir, do_index=False
         )
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
             test_tgz, product_7_15_8,
-            target=(TEST_BUCKET, None),
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir, do_index=False
         )
         test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
@@ -92,7 +92,7 @@ class NPMUploadTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, prefix),
+            targets=[(None, TEST_BUCKET, prefix)],
             dir_=self.tempdir, do_index=False
         )
 

--- a/tests/test_npm_upload.py
+++ b/tests/test_npm_upload.py
@@ -47,12 +47,16 @@ class NPMUploadTest(PackageBaseTest):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
-            test_tgz, product_7_14_5, bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            test_tgz, product_7_14_5,
+            target=(TEST_BUCKET, None),
+            dir_=self.tempdir, do_index=False
         )
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
-            test_tgz, product_7_15_8, bucket_name=TEST_BUCKET, dir_=self.tempdir, do_index=False
+            test_tgz, product_7_15_8,
+            target=(TEST_BUCKET, None),
+            dir_=self.tempdir, do_index=False
         )
         test_bucket = self.mock_s3.Bucket(TEST_BUCKET)
         objs = list(test_bucket.objects.all())
@@ -88,7 +92,7 @@ class NPMUploadTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET, prefix=prefix,
+            target=(TEST_BUCKET, prefix),
             dir_=self.tempdir, do_index=False
         )
 

--- a/tests/test_npm_upload_multi_tgts.py
+++ b/tests/test_npm_upload_multi_tgts.py
@@ -1,0 +1,194 @@
+"""
+Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/charon)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+
+from moto import mock_s3
+
+from charon.pkgs.npm import handle_npm_uploading
+from charon.pkgs.pkg_utils import is_metadata
+from charon.storage import CHECKSUM_META_KEY
+from charon.constants import PROD_INFO_SUFFIX
+from tests.base import LONG_TEST_PREFIX, SHORT_TEST_PREFIX, PackageBaseTest
+from tests.commons import (
+    TEST_BUCKET, CODE_FRAME_7_14_5_FILES,
+    CODE_FRAME_7_15_8_FILES, CODE_FRAME_META, TEST_BUCKET_2
+)
+
+
+@mock_s3
+class NPMUploadMultiTgtsTest(PackageBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.mock_s3.create_bucket(Bucket=TEST_BUCKET_2)
+        self.test_bucket_2 = self.mock_s3.Bucket(TEST_BUCKET_2)
+
+    def tearDown(self):
+        buckets = [TEST_BUCKET_2]
+        self.cleanBuckets(buckets)
+        super().tearDown()
+
+    def test_npm_upload(self):
+        self.__test_prefix()
+
+    def test_upload_with_short_prefix(self):
+        self.__test_prefix(SHORT_TEST_PREFIX)
+
+    def test_upload_with_long_prefix(self):
+        self.__test_prefix(LONG_TEST_PREFIX)
+
+    def test_upload_with_root_prefix(self):
+        self.__test_prefix("/")
+
+    def test_double_uploads(self):
+        targets_ = [(None, TEST_BUCKET, None), (None, TEST_BUCKET_2, None)]
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
+        product_7_14_5 = "code-frame-7.14.5"
+        handle_npm_uploading(
+            test_tgz, product_7_14_5,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
+        product_7_15_8 = "code-frame-7.15.8"
+        handle_npm_uploading(
+            test_tgz, product_7_15_8,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            self.assertEqual(9, len(actual_files), msg=f'{bucket_name}')
+
+            for f in CODE_FRAME_7_14_5_FILES:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+                self.check_product(f, [product_7_14_5], msg=f'{bucket_name}')
+            for f in CODE_FRAME_7_15_8_FILES:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+                self.check_product(f, [product_7_15_8], msg=f'{bucket_name}')
+            self.assertIn(CODE_FRAME_META, actual_files, msg=f'{bucket_name}')
+            # self.check_product(CODE_FRAME_META, product_mix)
+
+            meta_obj_client = bucket.Object(CODE_FRAME_META)
+            meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "\"name\": \"@babel/code-frame\"",
+                meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"description\": \"Generate errors that contain a code frame that point to "
+                "source locations.\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"repository\": {\"type\": \"git\", \"url\": "
+                "\"https://github.com/babel/babel.git\"",
+                meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"version\": \"7.15.8\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"version\": \"7.14.5\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"versions\": {", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"7.15.8\": {\"name\":", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"7.14.5\": {\"name\":", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"license\": \"MIT\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"dist_tags\": {\"latest\": \"7.15.8\"}", meta_content_client, msg=f'{bucket_name}'
+            )
+
+    def __test_prefix(self, prefix: str = None):
+        targets_ = [(None, TEST_BUCKET, prefix), (None, TEST_BUCKET_2, prefix)]
+        test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
+        product_7_14_5 = "code-frame-7.14.5"
+        handle_npm_uploading(
+            test_tgz, product_7_14_5,
+            targets=targets_,
+            dir_=self.tempdir, do_index=False
+        )
+
+        for target in targets_:
+            bucket_name = target[1]
+            bucket = self.mock_s3.Bucket(bucket_name)
+            objs = list(bucket.objects.all())
+            actual_files = [obj.key for obj in objs]
+            self.assertEqual(5, len(actual_files), msg=f'{bucket_name}')
+
+            PREFIXED_7145_FILES = CODE_FRAME_7_14_5_FILES
+            PREFIXED_FRAME_META = CODE_FRAME_META
+            if prefix and prefix != "/":
+                PREFIXED_7145_FILES = [
+                    os.path.join(prefix, f) for f in CODE_FRAME_7_14_5_FILES
+                ]
+                PREFIXED_FRAME_META = os.path.join(prefix, CODE_FRAME_META)
+            for f in PREFIXED_7145_FILES:
+                self.assertIn(f, actual_files, msg=f'{bucket_name}')
+            self.assertIn(PREFIXED_FRAME_META, actual_files, msg=f'{bucket_name}')
+
+            for o in objs:
+                if not o.key.endswith(PROD_INFO_SUFFIX):
+                    obj = o.Object()
+                    if not is_metadata(o.key):
+                        self.check_product(o.key, [product_7_14_5], msg=f'{bucket_name}')
+                    self.assertIn(CHECKSUM_META_KEY, obj.metadata, msg=f'{bucket_name}')
+                    self.assertNotEqual(
+                        "", obj.metadata[CHECKSUM_META_KEY].strip(),
+                        msg=f'{bucket_name}'
+                    )
+
+            meta_obj_client = bucket.Object(PREFIXED_FRAME_META)
+            meta_content_client = str(meta_obj_client.get()["Body"].read(), "utf-8")
+            self.assertIn(
+                "\"name\": \"@babel/code-frame\"", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"description\": \"Generate errors that contain a code frame that point to "
+                "source locations.\"", meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"repository\": {\"type\": \"git\", \"url\": "
+                "\"https://github.com/babel/babel.git\"",
+                meta_content_client, msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"version\": \"7.14.5\"", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"versions\": {\"7.14.5\":", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"license\": \"MIT\"", meta_content_client,
+                msg=f'{bucket_name}'
+            )
+            self.assertIn(
+                "\"dist_tags\": {\"latest\": \"7.14.5\"}",
+                meta_content_client, msg=f'{bucket_name}'
+            )

--- a/tests/test_pkgs_dryrun.py
+++ b/tests/test_pkgs_dryrun.py
@@ -28,7 +28,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir,
             dry_run=True
         )
@@ -44,7 +44,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir,
             dry_run=True
         )
@@ -88,7 +88,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -96,7 +96,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            targets=[(TEST_BUCKET, None)],
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 

--- a/tests/test_pkgs_dryrun.py
+++ b/tests/test_pkgs_dryrun.py
@@ -58,7 +58,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, None),
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir,
             dry_run=True
         )
@@ -74,7 +74,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, None),
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir,
             dry_run=True
         )
@@ -105,7 +105,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            target=(TEST_BUCKET, None),
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )
 
@@ -113,6 +113,6 @@ class PkgsDryRunTest(PackageBaseTest):
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
             test_tgz, product_7_15_8,
-            target=(TEST_BUCKET, None),
+            targets=[(None, TEST_BUCKET, None)],
             dir_=self.tempdir
         )

--- a/tests/test_pkgs_dryrun.py
+++ b/tests/test_pkgs_dryrun.py
@@ -28,7 +28,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product,
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir,
             dry_run=True
         )
@@ -44,7 +44,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_del(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET,
+            targets=[(TEST_BUCKET, None)],
             dir_=self.tempdir,
             dry_run=True
         )
@@ -58,7 +58,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET,
+            target=(TEST_BUCKET, None),
             dir_=self.tempdir,
             dry_run=True
         )
@@ -74,7 +74,7 @@ class PkgsDryRunTest(PackageBaseTest):
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_del(
             test_tgz, product_7_14_5,
-            bucket_name=TEST_BUCKET,
+            target=(TEST_BUCKET, None),
             dir_=self.tempdir,
             dry_run=True
         )
@@ -88,25 +88,31 @@ class PkgsDryRunTest(PackageBaseTest):
         product_456 = "commons-client-4.5.6"
         handle_maven_uploading(
             test_zip, product_456,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir
+            targets=[(TEST_BUCKET, None)],
+            dir_=self.tempdir
         )
 
         test_zip = os.path.join(os.getcwd(), "tests/input/commons-client-4.5.9.zip")
         product_459 = "commons-client-4.5.9"
         handle_maven_uploading(
             test_zip, product_459,
-            bucket_name=TEST_BUCKET, dir_=self.tempdir
+            targets=[(TEST_BUCKET, None)],
+            dir_=self.tempdir
         )
 
     def __prepare_npm_content(self):
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.14.5.tgz")
         product_7_14_5 = "code-frame-7.14.5"
         handle_npm_uploading(
-            test_tgz, product_7_14_5, bucket_name=TEST_BUCKET, dir_=self.tempdir
+            test_tgz, product_7_14_5,
+            target=(TEST_BUCKET, None),
+            dir_=self.tempdir
         )
 
         test_tgz = os.path.join(os.getcwd(), "tests/input/code-frame-7.15.8.tgz")
         product_7_15_8 = "code-frame-7.15.8"
         handle_npm_uploading(
-            test_tgz, product_7_15_8, bucket_name=TEST_BUCKET, dir_=self.tempdir
+            test_tgz, product_7_15_8,
+            target=(TEST_BUCKET, None),
+            dir_=self.tempdir
         )

--- a/tests/test_s3client.py
+++ b/tests/test_s3client.py
@@ -149,8 +149,10 @@ class S3ClientTest(BaseTest):
         (temp_root, root, all_files) = self.__prepare_files()
         bucket = self.mock_s3.Bucket(MY_BUCKET)
         # test upload existed files with the product. The product will be added to metadata
-        self.s3_client.upload_files(all_files, target=(MY_BUCKET, None), product="apache-commons",
-                                    root=root)
+        self.s3_client.upload_files(
+            all_files, targets=[(MY_BUCKET, None)],
+            product="apache-commons", root=root
+        )
 
         def content_check(products: List[str], objs: List[s3.ObjectSummary]):
             self.assertEqual(COMMONS_LANG3_ZIP_ENTRY, len(objs))
@@ -169,8 +171,10 @@ class S3ClientTest(BaseTest):
         content_check(["apache-commons"], objects)
 
         # test upload existed files with extra product. The extra product will be added to metadata
-        self.s3_client.upload_files(all_files, target=(MY_BUCKET, None), product="commons-lang3",
-                                    root=root)
+        self.s3_client.upload_files(
+            all_files, targets=[(MY_BUCKET, None)],
+            product="commons-lang3", root=root
+        )
         objects = list(bucket.objects.all())
         content_check(set(["apache-commons", "commons-lang3"]), objects)
 
@@ -197,7 +201,7 @@ class S3ClientTest(BaseTest):
 
         self.s3_client.upload_files(
             test_files,
-            target=(MY_BUCKET, SHORT_TEST_PREFIX),
+            targets=[(MY_BUCKET, SHORT_TEST_PREFIX)],
             product="apache-commons",
             root=root)
         objects = list(bucket.objects.all())
@@ -228,7 +232,8 @@ class S3ClientTest(BaseTest):
         overwrite_file(file, content1)
         sha1_1 = read_sha1(file)
         self.s3_client.upload_files(
-            [file], target=(MY_BUCKET, None), product="foo-bar-1.0", root=temp_root
+            [file], targets=[(MY_BUCKET, None)],
+            product="foo-bar-1.0", root=temp_root
         )
         objects = list(bucket.objects.all())
         self.assertEqual(2, len(objects))
@@ -248,7 +253,8 @@ class S3ClientTest(BaseTest):
         sha1_2 = read_sha1(file)
         self.assertNotEqual(sha1_1, sha1_2)
         self.s3_client.upload_files(
-            [file], target=(MY_BUCKET, None), product="foo-bar-1.0-2", root=temp_root
+            [file], targets=[(MY_BUCKET, None)],
+            product="foo-bar-1.0-2", root=temp_root
         )
         objects = list(bucket.objects.all())
         self.assertEqual(2, len(objects))
@@ -356,8 +362,8 @@ class S3ClientTest(BaseTest):
         shutil.rmtree(root)
 
         failed_paths = self.s3_client.upload_files(
-            all_files, target=(MY_BUCKET, None), product="apache-commons",
-            root=temp_root
+            all_files, targets=[(MY_BUCKET, None)],
+            product="apache-commons", root=temp_root
         )
 
         self.assertEqual(COMMONS_LANG3_ZIP_MVN_ENTRY, len(failed_paths))
@@ -365,8 +371,8 @@ class S3ClientTest(BaseTest):
     def test_exists_override_failing(self):
         (temp_root, _, all_files) = self.__prepare_files()
         failed_paths = self.s3_client.upload_files(
-            all_files, target=(MY_BUCKET, None), product="apache-commons",
-            root=temp_root
+            all_files, targets=[(MY_BUCKET, None)],
+            product="apache-commons", root=temp_root
         )
         self.assertEqual(0, len(failed_paths))
 
@@ -374,8 +380,8 @@ class S3ClientTest(BaseTest):
         with open(all_files[0], "w+", encoding="utf-8") as f:
             f.write("changed content")
         failed_paths = self.s3_client.upload_files(
-            all_files, target=(MY_BUCKET, None), product="apache-commons-2",
-            root=temp_root
+            all_files, targets=[(MY_BUCKET, None)],
+            product="apache-commons-2", root=temp_root
         )
         self.assertEqual(1, len(failed_paths))
         self.assertIn(failed_paths[0], all_files[0])


### PR DESCRIPTION
* Command options "target" can accept more than one targets now
* For files uploading, will pick first target as main target to do uploading, and then copy files from main target to other targets
* For files deletion, will delete from targets one by one
* All metadadata files updating will happened sequentially
* All s3 operations will happen asynchronously 