### PR TITLE
Fix: use bucket name as prefix for manifest file storage

### DIFF
--- a/charon/pkgs/maven.py
+++ b/charon/pkgs/maven.py
@@ -307,7 +307,7 @@ def handle_maven_uploading(
     targets_ = [(target[1], remove_prefix(target[2], "/")) for target in targets]
     logger.info(
         "Start uploading files to s3 buckets: %s",
-        [target[0] for target in targets_]
+        [target[1] for target in targets_]
     )
     failed_files = s3_client.upload_files(
         file_paths=valid_mvn_paths,
@@ -325,7 +325,7 @@ def handle_maven_uploading(
                 'uploading\n')
         else:
             logger.info("Start uploading manifest to s3 bucket %s", manifest_bucket_name)
-            manifest_folder = target[0]
+            manifest_folder = target[1]
             manifest_name, manifest_full_path = write_manifest(valid_mvn_paths, top_level, prod_key)
             s3_client.upload_manifest(
                 manifest_name, manifest_full_path,
@@ -468,7 +468,7 @@ def handle_maven_del(
         logger.info("Files deletion done\n")
 
         # 4. Delete related manifest from s3
-        manifest_folder = target[0]
+        manifest_folder = target[1]
         logger.info(
             "Start deleting manifest from s3 bucket %s in folder %s",
             manifest_bucket_name, manifest_folder

--- a/charon/pkgs/npm.py
+++ b/charon/pkgs/npm.py
@@ -100,7 +100,7 @@ def handle_npm_uploading(
     targets_ = [(target[1], remove_prefix(target[2], "/")) for target in targets]
     logger.info(
         "Start uploading files to s3 buckets: %s",
-        [target[0] for target in targets_]
+        [target[1] for target in targets_]
     )
     failed_files = client.upload_files(
         file_paths=valid_paths,
@@ -112,13 +112,13 @@ def handle_npm_uploading(
 
     succeeded = True
     for target in targets:
-        manifest_folder = target[0]
         if not manifest_bucket_name:
             logger.warning(
                 'Warning: No manifest bucket is provided, will ignore the process of manifest '
                 'uploading\n')
         else:
             logger.info("Start uploading manifest to s3 bucket %s", manifest_bucket_name)
+            manifest_folder = target[1]
             manifest_name, manifest_full_path = write_manifest(valid_paths, target_dir, product)
             client.upload_manifest(
                 manifest_name, manifest_full_path,
@@ -217,7 +217,7 @@ def handle_npm_del(
         logger.info("Files deletion done\n")
 
         if manifest_bucket_name:
-            manifest_folder = target[0]
+            manifest_folder = target[1]
             logger.info(
                 "Start deleting manifest from s3 bucket %s in folder %s",
                 manifest_bucket_name, manifest_folder

--- a/charon/storage.py
+++ b/charon/storage.py
@@ -418,8 +418,7 @@ class S3Client(object):
             manifest_bucket_name: str
     ):
         target = target if target else "default"
-        env_folder = "-".join([target, "charon-metadata"])
-        path_key = os.path.join(env_folder, manifest_name)
+        path_key = os.path.join(target, manifest_name)
         manifest_bucket = self.__get_bucket(manifest_bucket_name)
         try:
             file_object: s3.Object = manifest_bucket.Object(path_key)
@@ -551,8 +550,7 @@ class S3Client(object):
             return
         manifest_name = product_key + MANIFEST_SUFFIX
         target = target if target else "default"
-        env_folder = "-".join([target, "charon-metadata"])
-        path_key = os.path.join(env_folder, manifest_name)
+        path_key = os.path.join(target, manifest_name)
 
         manifest_bucket = self.__get_bucket(manifest_bucket_name)
         file_object: s3.Object = manifest_bucket.Object(path_key)

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -118,8 +118,8 @@ COMMONS_ROOT_INDEX = "index.html"
 # For manifest
 TEST_MANIFEST_BUCKET = "test_manifest_bucket"
 TEST_TARGET = "stage"
-COMMONS_CLIENT_456_MANIFEST = "stage-charon-metadata/commons-client-4.5.6.txt"
-CODE_FRAME_7_14_5_MANIFEST = "stage-charon-metadata/code-frame-7.14.5.txt"
+COMMONS_CLIENT_456_MANIFEST = TEST_BUCKET + "/commons-client-4.5.6.txt"
+CODE_FRAME_7_14_5_MANIFEST = TEST_BUCKET + "/code-frame-7.14.5.txt"
 
 # For multi targets support
 TEST_BUCKET_2 = "test_bucket_2"


### PR DESCRIPTION
    Use bucket name instead of target name as it will not change.