### PR TITLE
Fix missing check of the original malform "dist_tags"

### DIFF
--- a/charon/pkgs/npm.py
+++ b/charon/pkgs/npm.py
@@ -532,16 +532,20 @@ def _do_merge(original: NPMPackageMetadata, source: NPMPackageMetadata, is_lates
             original.time[t] = source.time.get(t)
             changed = True
     if source.dist_tags:
-        for d in source.dist_tags.keys():
-            if d not in original.dist_tags.keys():
-                original.dist_tags[d] = source.dist_tags.get(d)
-                changed = True
-            elif d in original.dist_tags.keys() and compare(
-                    source.dist_tags.get(d),
-                    original.dist_tags.get(d)
-            ) > 0:
-                original.dist_tags[d] = source.dist_tags.get(d)
-                changed = True
+        if original.dist_tags:
+            for d in source.dist_tags.keys():
+                if d not in original.dist_tags.keys():
+                    original.dist_tags[d] = source.dist_tags.get(d)
+                    changed = True
+                elif d in original.dist_tags.keys() and compare(
+                        source.dist_tags.get(d),
+                        original.dist_tags.get(d)
+                ) > 0:
+                    original.dist_tags[d] = source.dist_tags.get(d)
+                    changed = True
+        else:
+            original.dist_tags = source.dist_tags
+            changed = True
     if source.versions:
         for v in source.versions.keys():
             original.versions[v] = source.versions.get(v)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from setuptools import setup, find_packages
 
-version = "1.2.1"
+version = "1.2.2"
 
 # f = open('README.md')
 # long_description = f.read().strip()

--- a/tests/test_npm_meta.py
+++ b/tests/test_npm_meta.py
@@ -144,3 +144,54 @@ class NPMMetadataOnS3Test(BaseTest):
         self.assertIn("1.0.1", merged.keywords)
         self.assertEqual("1.0.1bugs", merged.bugs)
         self.assertEqual("Apache-2.0.1", merged.license)
+
+    def test_handle_npm_meta_wrong_dist_tags(self):
+        bucket = self.mock_s3.Bucket(MY_BUCKET)
+        original_version_0_5_8_package_json = """
+        {"name": "@redhat/kogito-tooling-workspace",
+        "dist_tags": {"latest": "0.5.8"},"versions": {"0.5.8": {"name":
+        "@redhat/kogito-tooling-workspace", "version": "0.5.8", "title": "0.5.8title",
+        "description": "0.5.8description", "keywords": ["0.5.8"], "maintainers": [
+        "0.5.8maintainer"], "repository": {"type": "git", "url": "https://github.com/0.5.8.git"},
+        "bugs": "0.5.8bugs", "license": "Apache-2.0.1", "dependencies": {
+        "@redhat/kogito-tooling-channel-common-api": "^0.5.8"}}}, "maintainers": [
+        "0.5.8maintainer"], "description": "0.5.8 description", "time": {}, "author":
+        "0.5.8author", "users": {"0.5.8users": true}, "repository": {"type": "git",
+        "url": "https://github.com/0.5.8.git"}, "readme": "0.5.8readme", "readmeFilename":
+        "0.5.8readmeFilename", "homepage": "0.5.8homepage", "keywords": ["0.5.8"],
+        "bugs": "0.5.8bugs", "license": "Apache-2.0.1"}"""
+
+        bucket.put_object(
+            Key='@redhat/kogito-tooling-workspace/package.json',
+            Body=str(original_version_0_5_8_package_json)
+        )
+        tarball_test_path = os.path.join(INPUTS, 'kogito-tooling-workspace-0.9.0-3.tgz')
+        handle_npm_uploading(
+            tarball_test_path, "kogito-tooling-workspace-0.9.0-3",
+            buckets=[('', MY_BUCKET, '', DEFAULT_REGISTRY)],
+            dir_=self.tempdir
+        )
+        (files, _) = self.s3_client.get_files(
+            bucket_name=MY_BUCKET,
+            prefix='@redhat/kogito-tooling-workspace/package.json'
+        )
+        self.assertEqual(1, len(files))
+        self.assertIn('@redhat/kogito-tooling-workspace/package.json', files)
+
+        content = self.s3_client.read_file_content(
+            MY_BUCKET,
+            '@redhat/kogito-tooling-workspace/package.json'
+        )
+        merged = read_package_metadata_from_content(content, False)
+        self.assertEqual("@redhat/kogito-tooling-workspace", merged.name)
+        self.assertEqual(2, len(merged.versions))
+        self.assertIn("0.5.8", list(merged.versions.keys()))
+        self.assertIn("0.9.0-3", list(merged.versions.keys()))
+        self.assertEqual("0.9.0-3", merged.dist_tags["latest"])
+        self.assertIn("0.5.8maintainer", merged.maintainers)
+        self.assertIn("0.5.8users", merged.users.keys())
+        self.assertEqual("https://github.com/kiegroup/kogito-tooling.git", merged.repository["url"])
+        self.assertEqual("0.5.8homepage", merged.homepage)
+        self.assertIn("0.5.8", merged.keywords)
+        self.assertEqual("0.5.8bugs", merged.bugs)
+        self.assertEqual("Apache-2.0", merged.license)

--- a/tests/test_npm_upload.py
+++ b/tests/test_npm_upload.py
@@ -87,6 +87,7 @@ class NPMUploadTest(PackageBaseTest):
         self.assertIn("\"7.14.5\": {\"name\":", meta_content_client)
         self.assertIn("\"license\": \"MIT\"", meta_content_client)
         self.assertIn("\"dist-tags\": {\"latest\": \"7.15.8\"}", meta_content_client)
+        self.assertNotIn("\"dist_tags\":", meta_content_client)
 
     def __test_prefix(self, prefix: str = None):
         test_tgz = os.path.join(INPUTS, "code-frame-7.14.5.tgz")
@@ -132,3 +133,4 @@ class NPMUploadTest(PackageBaseTest):
         self.assertIn("\"versions\": {\"7.14.5\":", meta_content_client)
         self.assertIn("\"license\": \"MIT\"", meta_content_client)
         self.assertIn("\"dist-tags\": {\"latest\": \"7.14.5\"}", meta_content_client)
+        self.assertNotIn("\"dist_tags\":", meta_content_client)

--- a/tests/test_npm_upload_multi_tgts.py
+++ b/tests/test_npm_upload_multi_tgts.py
@@ -123,6 +123,7 @@ class NPMUploadMultiTgtsTest(PackageBaseTest):
             self.assertIn(
                 "\"dist-tags\": {\"latest\": \"7.15.8\"}", meta_content_client, msg=f'{bucket_name}'
             )
+            self.assertNotIn("\"dist_tags\":", meta_content_client)
 
     def __test_prefix(self, prefix: str = None):
         targets_ = [('', TEST_BUCKET, prefix, DEFAULT_REGISTRY),
@@ -195,3 +196,4 @@ class NPMUploadMultiTgtsTest(PackageBaseTest):
                 "\"dist-tags\": {\"latest\": \"7.14.5\"}",
                 meta_content_client, msg=f'{bucket_name}'
             )
+            self.assertNotIn("\"dist_tags\":", meta_content_client)


### PR DESCRIPTION
   Recent fix has changed "dist_tags" to "dist-tags" usage, but forgot
   to check the original content which has been published in Ronda,
   which is still using "dist_tags". This makes the original content
   miss the meta.dist_tags field, which caused error