### PR TITLE
Enable test_check_invalidation for CloudFront test

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,5 +5,5 @@ pytest-cov
 pytest-html
 flake8
 requests-mock
-moto>=5.0.3,<6
+moto>=5.0.16,<6
 python-gnupg>=0.5.0,<1

--- a/tests/test_cf_reindex.py
+++ b/tests/test_cf_reindex.py
@@ -27,6 +27,10 @@ import pytest
 
 @mock_aws
 class CFReIndexTest(CFBasedTest):
+    '''
+    This test is deprecated because the cf invalidation after re_index
+    is not used anymore.
+    '''
     @pytest.mark.skip(reason="Indexing CF invalidation is abandoned")
     def test_cf_maven_after_reindex(self):
         response = self.mock_cf.list_invalidations(DistributionId=self.test_dist_id)

--- a/tests/test_cfclient.py
+++ b/tests/test_cfclient.py
@@ -18,7 +18,6 @@ from tests.constants import TEST_DS_CONFIG
 from charon.cache import CFClient
 from moto import mock_aws
 import boto3
-import pytest
 
 
 @mock_aws
@@ -62,10 +61,6 @@ class CFClientTest(BaseTest):
             self.assertTrue(r['Id'])
             self.assertEqual('completed', str.lower(r['Status']))
 
-    @pytest.mark.skip(reason="""
-        Because current moto 5.0.3 has not implemented the get_invalidation(),
-        this test will fail. Will enable it when the it is implemented in future moto
-    """)
     def test_check_invalidation(self):
         dist_id = self.cf_client.get_dist_id_by_domain("maven.repository.redhat.com")
         result = self.cf_client.invalidate_paths(dist_id, ["/*"])


### PR DESCRIPTION
   As moto 5.0.16 added support fot get_invalidation