### PR TITLE
Fix mmeng-4362: re-sort the indexing page items

### DIFF
--- a/charon/pkgs/indexing.py
+++ b/charon/pkgs/indexing.py
@@ -23,7 +23,7 @@ from charon.utils.files import digest_content
 from jinja2 import Template
 import os
 import logging
-from typing import List, Set, Dict
+from typing import List, Dict
 
 from charon.utils.strings import remove_prefix
 
@@ -48,7 +48,7 @@ NPM_INDEX_TEMPLATE = __get_index_template(PACKAGE_TYPE_NPM)
 
 class IndexedHTML(object):
     # object for holding index html file data
-    def __init__(self, title: str, header: str, items: Set[str]):
+    def __init__(self, title: str, header: str, items: List[str]):
         self.title = title
         self.header = header
         self.items = items
@@ -174,8 +174,8 @@ def __to_html_content(package_type: str, contents: List[str], folder: str) -> st
             items = temp_items
     else:
         items.extend(contents)
-    items_set = set(__sort_index_items(items))
-    index = IndexedHTML(title=folder, header=folder, items=items_set)
+    items_result = list(filter(lambda c: c.strip(), __sort_index_items(set(items))))
+    index = IndexedHTML(title=folder, header=folder, items=items_result)
     return index.generate_index_file_content(package_type)
 
 
@@ -303,8 +303,8 @@ def re_index(
                         real_contents.append(c)
         else:
             real_contents = contents
-        logger.debug(real_contents)
         index_content = __to_html_content(package_type, real_contents, path)
+        logger.debug("The re-indexed page content: %s", index_content)
         if not dry_run:
             index_path = os.path.join(path, "index.html")
             if path == "/":


### PR DESCRIPTION
Seems the order of link items in the index.html for each folder is not correct. This PR will fix it.