### PR TITLE
RADAS: change the request_queue to request_channel in config

### DIFF
--- a/charon/config.py
+++ b/charon/config.py
@@ -30,7 +30,7 @@ class RadasConfig(object):
         self.__umb_host: str = data.get("umb_host", None)
         self.__umb_host_port: str = data.get("umb_host_port", "5671")
         self.__result_queue: str = data.get("result_queue", None)
-        self.__request_queue: str = data.get("request_queue", None)
+        self.__request_chan: str = data.get("request_channel", None)
         self.__client_ca: str = data.get("client_ca", None)
         self.__client_key: str = data.get("client_key", None)
         self.__client_key_pass_file: str = data.get("client_key_pass_file", None)
@@ -51,7 +51,7 @@ class RadasConfig(object):
         if not self.__result_queue:
             logger.error("Missing the queue setting to receive signing result in UMB!")
             return False
-        if not self.__request_queue:
+        if not self.__request_chan:
             logger.error("Missing the queue setting to send signing request in UMB!")
             return False
         if self.__client_ca and not os.access(self.__client_ca, os.R_OK):
@@ -81,8 +81,8 @@ class RadasConfig(object):
     def result_queue(self) -> str:
         return self.__result_queue.strip()
 
-    def request_queue(self) -> str:
-        return self.__request_queue.strip()
+    def request_channel(self) -> str:
+        return self.__request_chan.strip()
 
     def client_ca(self) -> str:
         return self.__client_ca.strip()

--- a/charon/pkgs/radas_sign.py
+++ b/charon/pkgs/radas_sign.py
@@ -206,7 +206,7 @@ class RadasSender(MessagingHandler):
             ssl_domain=self._ssl
         )
         if conn:
-            self._sender = self._container.create_sender(conn, self.rconf.request_queue())
+            self._sender = self._container.create_sender(conn, self.rconf.request_channel())
 
     def on_sendable(self, event):
         if not self._message_sent:

--- a/tests/test_config_radas.py
+++ b/tests/test_config_radas.py
@@ -36,7 +36,7 @@ class RadasConfigTest(unittest.TestCase):
 radas:
     umb_host: test.umb.api.com
     result_queue: queue.result.test
-    request_queue: queue.request.test
+    request_channel: topic://topic.request.test
     client_ca: {}
     client_key: {}
     client_key_pass_file: {}
@@ -59,7 +59,7 @@ targets:
         radas_settings = """
 radas:
     result_queue: queue.result.test
-    request_queue: queue.request.test
+    request_channel: topic://topic.request.test
     client_ca: {}
     client_key: {}
     client_key_pass_file: {}
@@ -79,7 +79,7 @@ targets:
         radas_settings = """
 radas:
     umb_host: test.umb.api.com
-    request_queue: queue.request.test
+    request_channel: topic://topic.request.test
     client_ca: {}
     client_key: {}
     client_key_pass_file: {}
@@ -120,7 +120,7 @@ targets:
 radas:
     umb_host: test.umb.api.com
     result_queue: queue.result.test
-    request_queue: queue.request.test
+    request_channel: topic://topic.request.test
     client_ca: {}
     client_key: {}
     client_key_pass_file: {}
@@ -142,7 +142,7 @@ targets:
 radas:
     umb_host: test.umb.api.com
     result_queue: queue.result.test
-    request_queue: queue.request.test
+    request_channel: topic://topic.request.test
     client_ca: {}
     client_key: {}
     client_key_pass_file: {}
@@ -164,7 +164,7 @@ targets:
 radas:
     umb_host: test.umb.api.com
     result_queue: queue.result.test
-    request_queue: queue.request.test
+    request_channel: topic://topic.request.test
     client_ca: {}
     client_key: {}
     client_key_pass_file: {}
@@ -186,7 +186,7 @@ targets:
 radas:
     umb_host: test.umb.api.com
     result_queue: queue.result.test
-    request_queue: queue.request.test
+    request_channel: topic://topic.request.test
     client_ca: {}
     client_key: {}
     client_key_pass_file: {}


### PR DESCRIPTION
   As topic is also a valid destination to send, use queue is not
   correct